### PR TITLE
Add currency-locked story paths and admin controls

### DIFF
--- a/controllers/admin.controller.js
+++ b/controllers/admin.controller.js
@@ -953,13 +953,21 @@ exports.storyEndingUpdatePosition = async (req, res) => {
 exports.nodeChoiceAddInline = async (req, res) => {
   try {
     const { label, nextNodeId } = req.body;
+    const locked = Boolean(req.body.locked);
+    const parsedCost = Number(req.body.unlockCost);
+    const unlockCost = Number.isFinite(parsedCost) ? Math.max(parsedCost, 0) : 0;
     const story = await Story.findById(req.params.id);
     if (!story) return respondError(req, res, 404, "Story not found");
 
     const node = story.nodes.find((n) => n._id === req.params.nodeId);
     if (!node) return respondError(req, res, 404, "Node not found");
 
-    node.choices.push({ label, nextNodeId });
+    node.choices.push({
+      label,
+      nextNodeId,
+      locked,
+      unlockCost: locked ? unlockCost : 0,
+    });
     await story.save();
     return respondWithStory(
       req,
@@ -976,6 +984,9 @@ exports.nodeChoiceAddInline = async (req, res) => {
 exports.nodeChoiceUpdateInline = async (req, res) => {
   try {
     const { label, nextNodeId } = req.body;
+    const locked = Boolean(req.body.locked);
+    const parsedCost = Number(req.body.unlockCost);
+    const unlockCost = Number.isFinite(parsedCost) ? Math.max(parsedCost, 0) : 0;
     const story = await Story.findById(req.params.id);
     if (!story) return respondError(req, res, 404, "Story not found");
 
@@ -987,6 +998,8 @@ exports.nodeChoiceUpdateInline = async (req, res) => {
 
     choice.label = label;
     choice.nextNodeId = nextNodeId;
+    choice.locked = locked;
+    choice.unlockCost = locked ? unlockCost : 0;
 
     await story.save();
     return respondWithStory(

--- a/controllers/story.controller.js
+++ b/controllers/story.controller.js
@@ -288,7 +288,7 @@ exports.unlockChoice = async (req, res) => {
   if (user.currency < cost) {
     req.session.choiceUnlockFeedback = {
       type: "error",
-      message: `You need ${cost} currency to unlock this choice.`,
+      message: `You need ${cost} gems to unlock this choice.`,
     };
     return res.redirect(redirectUrl);
   }
@@ -302,7 +302,7 @@ exports.unlockChoice = async (req, res) => {
 
   const successMessage =
     cost > 0
-      ? `Unlocked "${choice.label}" for ${cost} currency!`
+      ? `Unlocked "${choice.label}" for ${cost} gems!`
       : `Unlocked "${choice.label}"!`;
 
   req.session.choiceUnlockFeedback = {

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -87,6 +87,18 @@ exports.stats = async (req, res) => {
         gold: 5,
         platinum: 10,
       }),
+      trueEndings: gradeTrophy(trueEndingsFound, {
+        bronze: 1,
+        silver: 3,
+        gold: 5,
+        platinum: 10,
+      }),
+      deathEndings: gradeTrophy(deathEndingsFound, {
+        bronze: 1,
+        silver: 5,
+        gold: 10,
+        platinum: 20,
+      }),
       secretEndings: gradeTrophy(secretEndingsFound, {
         bronze: 1,
         silver: 3,
@@ -117,6 +129,26 @@ exports.stats = async (req, res) => {
           storiesCompleted === 1
             ? "1 story finished"
             : `${storiesCompleted} stories finished`,
+      },
+      {
+        key: "trueEndings",
+        label: "True Endings",
+        level: trophyLevels.trueEndings,
+        levelLabel: formatLevel(trophyLevels.trueEndings),
+        progressText:
+          trueEndingsFound === 1
+            ? "1 true ending discovered"
+            : `${trueEndingsFound} true endings discovered`,
+      },
+      {
+        key: "deathEndings",
+        label: "Death Endings",
+        level: trophyLevels.deathEndings,
+        levelLabel: formatLevel(trophyLevels.deathEndings),
+        progressText:
+          deathEndingsFound === 1
+            ? "1 death ending uncovered"
+            : `${deathEndingsFound} death endings uncovered`,
       },
       {
         key: "secretEndings",
@@ -155,6 +187,24 @@ exports.stats = async (req, res) => {
           "Silver: Finish 3 stories",
           "Gold: Finish 5 stories",
           "Platinum: Finish 10 stories",
+        ],
+      },
+      {
+        label: "True Endings Trophy",
+        requirements: [
+          "Bronze: Discover 1 true ending",
+          "Silver: Discover 3 true endings",
+          "Gold: Discover 5 true endings",
+          "Platinum: Discover 10 true endings",
+        ],
+      },
+      {
+        label: "Death Endings Trophy",
+        requirements: [
+          "Bronze: Uncover 1 death ending",
+          "Silver: Uncover 5 death endings",
+          "Gold: Uncover 10 death endings",
+          "Platinum: Uncover 20 death endings",
         ],
       },
       {

--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -8,24 +8,199 @@ exports.stats = async (req, res) => {
       "progress.story"
     );
 
-    // Compute "stories completed" = all endings found for that story
+    if (!user) {
+      return res.status(404).render("user/stats", {
+        title: "My Stats",
+        dbUser: null,
+        storiesCompleted: 0,
+        overview: {
+          totalEndingsFound: 0,
+          storiesStarted: 0,
+          storiesCreated: 0,
+          trueEndingsFound: 0,
+          deathEndingsFound: 0,
+          secretEndingsFound: 0,
+          pathsUnlocked: 0,
+        },
+        trophies: [],
+        trophyRequirements: [],
+      });
+    }
+
     const allStories = await Story.find().select("_id endings");
+    const storyMap = new Map(
+      allStories.map((story) => [String(story._id), story])
+    );
+
+    const storiesStarted = user.progress.filter((p) => Boolean(p.story)).length;
     let storiesCompleted = 0;
+    let totalEndingsFound = 0;
+    let trueEndingsFound = 0;
+    let deathEndingsFound = 0;
+    let secretEndingsFound = 0;
+    let pathsUnlocked = 0;
 
     user.progress.forEach((p) => {
-      const st = allStories.find((s) => s._id.equals(p.story?._id || p.story));
-      const total = st?.endings?.length || 0;
-      const found = p.endingsFound?.length || 0;
-      if (total > 0 && found >= total) storiesCompleted++;
+      const storyId = String(p.story?._id || p.story || "");
+      const story = storyMap.get(storyId);
+      const endings = Array.isArray(story?.endings) ? story.endings : [];
+      const endingsById = new Map(
+        endings.map((ending) => [String(ending._id), ending])
+      );
+
+      const foundSet = new Set((p.endingsFound || []).map((id) => String(id)));
+      totalEndingsFound += foundSet.size;
+
+      if (endings.length > 0 && foundSet.size >= endings.length) {
+        storiesCompleted += 1;
+      }
+
+      foundSet.forEach((endingId) => {
+        const ending = endingsById.get(endingId);
+        if (!ending) return;
+        if (ending.type === "true") trueEndingsFound += 1;
+        if (ending.type === "death") deathEndingsFound += 1;
+        if (ending.type === "secret") secretEndingsFound += 1;
+      });
+
+      if (Array.isArray(p.unlockedChoices)) {
+        pathsUnlocked += p.unlockedChoices.length;
+      }
     });
 
-    // You can store it or just render it
-    user.storiesRead = storiesCompleted; // reuse the field; it now means "completed"
+    user.storiesRead = storiesCompleted; // reuse the field to reflect completions
+
+    const storiesCreated = 0; // placeholder until authoring stats are tracked
+
+    const gradeTrophy = (value, thresholds) => {
+      if (value >= thresholds.platinum) return "platinum";
+      if (value >= thresholds.gold) return "gold";
+      if (value >= thresholds.silver) return "silver";
+      if (value >= thresholds.bronze) return "bronze";
+      return "none";
+    };
+
+    const trophyLevels = {
+      storiesCompleted: gradeTrophy(storiesCompleted, {
+        bronze: 1,
+        silver: 3,
+        gold: 5,
+        platinum: 10,
+      }),
+      secretEndings: gradeTrophy(secretEndingsFound, {
+        bronze: 1,
+        silver: 3,
+        gold: 5,
+        platinum: 10,
+      }),
+      storyBuilder: "none",
+      bigSpender: gradeTrophy(pathsUnlocked, {
+        bronze: 1,
+        silver: 5,
+        gold: 10,
+        platinum: 20,
+      }),
+    };
+
+    const formatLevel = (level) =>
+      level === "none"
+        ? "No trophy yet"
+        : `${level.charAt(0).toUpperCase()}${level.slice(1)}`;
+
+    const trophies = [
+      {
+        key: "storiesCompleted",
+        label: "Stories Completed",
+        level: trophyLevels.storiesCompleted,
+        levelLabel: formatLevel(trophyLevels.storiesCompleted),
+        progressText:
+          storiesCompleted === 1
+            ? "1 story finished"
+            : `${storiesCompleted} stories finished`,
+      },
+      {
+        key: "secretEndings",
+        label: "Secret Endings",
+        level: trophyLevels.secretEndings,
+        levelLabel: formatLevel(trophyLevels.secretEndings),
+        progressText:
+          secretEndingsFound === 1
+            ? "1 secret ending discovered"
+            : `${secretEndingsFound} secret endings discovered`,
+      },
+      {
+        key: "storyBuilder",
+        label: "Story Builder",
+        level: trophyLevels.storyBuilder,
+        levelLabel: "Coming soon",
+        progressText: "Create and publish adventures to earn this trophy.",
+      },
+      {
+        key: "bigSpender",
+        label: "Big Spender",
+        level: trophyLevels.bigSpender,
+        levelLabel: formatLevel(trophyLevels.bigSpender),
+        progressText:
+          pathsUnlocked === 1
+            ? "1 path unlocked"
+            : `${pathsUnlocked} paths unlocked`,
+      },
+    ];
+
+    const trophyRequirements = [
+      {
+        label: "Stories Completed Trophy",
+        requirements: [
+          "Bronze: Finish 1 story",
+          "Silver: Finish 3 stories",
+          "Gold: Finish 5 stories",
+          "Platinum: Finish 10 stories",
+        ],
+      },
+      {
+        label: "Secret Endings Trophy",
+        requirements: [
+          "Bronze: Find 1 secret ending",
+          "Silver: Find 3 secret endings",
+          "Gold: Find 5 secret endings",
+          "Platinum: Find 10 secret endings",
+        ],
+      },
+      {
+        label: "Story Builder Trophy",
+        requirements: [
+          "Bronze: Publish your first story (coming soon)",
+          "Silver: Publish 3 stories (coming soon)",
+          "Gold: Publish 5 stories (coming soon)",
+          "Platinum: Publish 10 stories (coming soon)",
+        ],
+      },
+      {
+        label: "Big Spender Trophy",
+        requirements: [
+          "Bronze: Unlock 1 path",
+          "Silver: Unlock 5 paths",
+          "Gold: Unlock 10 paths",
+          "Platinum: Unlock 20 paths",
+        ],
+      },
+    ];
 
     res.render("user/stats", {
       title: "My Stats",
       dbUser: user,
       storiesCompleted,
+      overview: {
+        totalEndingsFound,
+        storiesStarted,
+        storiesCreated,
+        trueEndingsFound,
+        deathEndingsFound,
+        secretEndingsFound,
+        pathsUnlocked,
+      },
+      trophies,
+      trophyRequirements,
     });
   } catch (err) {
     console.error(err);

--- a/models/story.model.js
+++ b/models/story.model.js
@@ -4,6 +4,8 @@ const choiceSchema = new mongoose.Schema(
   {
     label: String,
     nextNodeId: String,
+    locked: { type: Boolean, default: false },
+    unlockCost: { type: Number, default: 0 },
   },
   { _id: true }
 );

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -15,6 +15,7 @@ const userSchema = new mongoose.Schema(
         trueEndingFound: { type: Boolean, default: false },
         deathEndingCount: { type: Number, default: 0 },
         lastNodeId: { type: String, default: null },
+        unlockedChoices: [{ type: String }],
       },
     ],
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -109,6 +109,116 @@ nav a:hover {
   background: var(--accent-purple);
 }
 
+.choices {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  margin-top: 1.5rem;
+}
+
+.choices .cta-button,
+.choice-unlock-form {
+  width: 100%;
+}
+
+.choice-unlock-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cta-button.locked {
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(250, 204, 21, 0.6);
+  color: #fef9c3;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+}
+
+.cta-button.locked:hover {
+  background: rgba(250, 204, 21, 0.18);
+  color: #fefce8;
+}
+
+.cta-button.locked[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+  background: rgba(15, 23, 42, 0.7);
+  color: rgba(226, 232, 240, 0.6);
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+.cta-button.locked[disabled]:hover {
+  background: rgba(15, 23, 42, 0.7);
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.cta-button-unlocked {
+  background: rgba(59, 130, 246, 0.18);
+  color: #bfdbfe;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+}
+
+.cta-button-unlocked:hover {
+  background: rgba(59, 130, 246, 0.3);
+}
+
+.choice-label {
+  font-weight: 600;
+}
+
+.choice-cost {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.unlock-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(248, 250, 252, 0.75);
+}
+
+.notice {
+  margin-top: 1.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-size: 0.95rem;
+}
+
+.notice--success {
+  background: rgba(16, 185, 129, 0.16);
+  color: #bbf7d0;
+  border: 1px solid rgba(16, 185, 129, 0.4);
+}
+
+.notice--error {
+  background: rgba(239, 68, 68, 0.18);
+  color: #fecaca;
+  border: 1px solid rgba(239, 68, 68, 0.45);
+}
+
+.notice--info {
+  background: rgba(56, 189, 248, 0.18);
+  color: #bae6fd;
+  border: 1px solid rgba(56, 189, 248, 0.45);
+}
+
+.currency-readout {
+  margin-top: 1.75rem;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.85);
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.currency-readout strong {
+  font-size: 1.1rem;
+  color: #fef3c7;
+}
+
 .teaser {
   margin-top: 3rem;
   max-width: 800px;

--- a/public/styles.css
+++ b/public/styles.css
@@ -3,6 +3,9 @@
   --text-light: #f5f5f5;
   --accent-red: #b22222;
   --accent-purple: #5d3fd3;
+  --accent-blue: #2563eb;
+  --accent-blue-dark: #1d4ed8;
+  --accent-blue-darker: #1e3a8a;
   --muted-gray: #2c2c2c;
 }
 
@@ -147,48 +150,66 @@ nav a:hover {
   gap: 1rem;
   width: 100%;
   max-width: 800px;
+  min-width: 400px;
   margin: 0.35rem auto;
   padding: 0.85rem 1.25rem;
   text-decoration: none;
   box-sizing: border-box;
+  background: var(--accent-blue);
+  color: #f8fafc;
+  border: 2px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  transition: background 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.choice-button:hover {
+  background: var(--accent-blue-dark);
+  border-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.25);
 }
 
 .cta-button.locked {
-  background: var(--accent-red);
-  border-color: rgba(250, 204, 21, 0.7);
-  color: #fff8dc;
+  background: var(--accent-blue-darker);
+  border-color: rgba(250, 204, 21, 0.55);
+  color: #fefce8;
 }
 
 .cta-button.locked:hover {
-  background: #c53030;
-  border-color: rgba(250, 204, 21, 0.85);
-  color: #fffaf0;
+  background: #1c3a92;
+  border-color: rgba(250, 204, 21, 0.75);
+  color: #fffdec;
 }
 
 .cta-button.locked[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
-  background: #7f1d1d;
-  color: rgba(254, 242, 242, 0.75);
-  border-color: rgba(250, 204, 21, 0.45);
+  background: #1e3a8a;
+  color: rgba(240, 249, 255, 0.75);
+  border-color: rgba(250, 204, 21, 0.35);
 }
 
 .cta-button.locked[disabled]:hover {
-  background: #7f1d1d;
-  border-color: rgba(250, 204, 21, 0.45);
-  color: rgba(254, 242, 242, 0.75);
+  background: #1e3a8a;
+  border-color: rgba(250, 204, 21, 0.35);
+  color: rgba(240, 249, 255, 0.75);
 }
 
 .cta-button-unlocked {
-  background: var(--accent-red);
-  border-color: rgba(59, 130, 246, 0.55);
-  color: #f8fafc;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15) inset;
+  background: var(--accent-blue);
+  border-color: rgba(96, 165, 250, 0.75);
+  color: #f0f9ff;
+  box-shadow: 0 0 0 2px rgba(191, 219, 254, 0.55) inset, 0 8px 16px rgba(59, 130, 246, 0.35);
 }
 
 .cta-button-unlocked:hover {
-  border-color: rgba(59, 130, 246, 0.75);
-  background: #c53030;
+  border-color: rgba(59, 130, 246, 0.95);
+  background: var(--accent-blue-dark);
+}
+
+@media (max-width: 480px) {
+  .choice-button {
+    min-width: 0;
+  }
 }
 
 .choice-main {

--- a/public/styles.css
+++ b/public/styles.css
@@ -114,6 +114,7 @@ nav a:hover {
   background: var(--accent-purple);
 }
 
+
 .choices {
   display: flex;
   flex-direction: column;
@@ -139,7 +140,17 @@ nav a:hover {
 }
 
 .choice-button {
+  align-self: center;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+  max-width: 800px;
+  margin: 0.35rem auto;
+  padding: 0.85rem 1.25rem;
   text-decoration: none;
+  box-sizing: border-box;
 }
 
 .cta-button.locked {
@@ -181,10 +192,17 @@ nav a:hover {
 }
 
 .choice-main {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.75rem;
   font-weight: 600;
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+}
+
+.choice-label {
+  overflow-wrap: anywhere;
 }
 
 .choice-icon svg {
@@ -213,6 +231,7 @@ nav a:hover {
   gap: 0.35rem;
   font-size: 0.95rem;
   font-weight: 600;
+  margin-left: auto;
 }
 
 .choice-cost-value {
@@ -614,22 +633,6 @@ nav a:hover {
   margin: 1rem 0;
 }
 
-.choice-button {
-  display: block;
-  width: 100%;
-  max-width: 400px;
-  margin: 0.5rem auto;
-  padding: 0.75rem 1rem;
-  background: var(--accent-purple);
-  color: white;
-  border: none;
-  border-radius: 6px;
-  font-size: 1rem;
-  font-weight: bold;
-  cursor: pointer;
-  transition: background 0.3s;
-  text-align: center;
-}
 
 /*Ending progress in story cards */
 .ending-progress {

--- a/public/styles.css
+++ b/public/styles.css
@@ -102,7 +102,12 @@ nav a:hover {
   font-size: 1rem;
   font-weight: bold;
   cursor: pointer;
-  transition: background 0.3s;
+  transition: background 0.3s, border-color 0.3s, transform 0.2s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  text-decoration: none;
 }
 
 .cta-button:hover {
@@ -121,57 +126,98 @@ nav a:hover {
   width: 100%;
 }
 
+.choices .cta-button {
+  justify-content: space-between;
+  border: 2px solid transparent;
+  box-sizing: border-box;
+}
+
 .choice-unlock-form {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
 }
 
+.choice-button {
+  text-decoration: none;
+}
+
 .cta-button.locked {
-  background: rgba(30, 41, 59, 0.8);
-  border: 1px solid rgba(250, 204, 21, 0.6);
-  color: #fef9c3;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.15rem;
+  background: var(--accent-red);
+  border-color: rgba(250, 204, 21, 0.7);
+  color: #fff8dc;
 }
 
 .cta-button.locked:hover {
-  background: rgba(250, 204, 21, 0.18);
-  color: #fefce8;
+  background: #c53030;
+  border-color: rgba(250, 204, 21, 0.85);
+  color: #fffaf0;
 }
 
 .cta-button.locked[disabled] {
   cursor: not-allowed;
-  opacity: 0.6;
-  background: rgba(15, 23, 42, 0.7);
-  color: rgba(226, 232, 240, 0.6);
-  border-color: rgba(148, 163, 184, 0.4);
+  opacity: 0.65;
+  background: #7f1d1d;
+  color: rgba(254, 242, 242, 0.75);
+  border-color: rgba(250, 204, 21, 0.45);
 }
 
 .cta-button.locked[disabled]:hover {
-  background: rgba(15, 23, 42, 0.7);
-  color: rgba(226, 232, 240, 0.6);
+  background: #7f1d1d;
+  border-color: rgba(250, 204, 21, 0.45);
+  color: rgba(254, 242, 242, 0.75);
 }
 
 .cta-button-unlocked {
-  background: rgba(59, 130, 246, 0.18);
-  color: #bfdbfe;
-  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: var(--accent-red);
+  border-color: rgba(59, 130, 246, 0.55);
+  color: #f8fafc;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15) inset;
 }
 
 .cta-button-unlocked:hover {
-  background: rgba(59, 130, 246, 0.3);
+  border-color: rgba(59, 130, 246, 0.75);
+  background: #c53030;
 }
 
-.choice-label {
+.choice-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
   font-weight: 600;
 }
 
+.choice-icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.choice-cost .icon svg {
+  color: #fcd34d;
+}
+
 .choice-cost {
-  font-size: 0.85rem;
-  opacity: 0.85;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.choice-cost-value {
+  min-width: 1.5rem;
+  text-align: right;
 }
 
 .unlock-hint {
@@ -206,16 +252,39 @@ nav a:hover {
 }
 
 .currency-readout {
-  margin-top: 1.75rem;
+  margin-top: 2rem;
   font-size: 0.95rem;
   color: rgba(226, 232, 240, 0.85);
-  display: flex;
-  align-items: baseline;
-  gap: 0.35rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
 }
 
-.currency-readout strong {
-  font-size: 1.1rem;
+.currency-readout .icon svg {
+  width: 1.35rem;
+  height: 1.35rem;
+  color: #fcd34d;
+}
+
+.currency-readout__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.currency-readout__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(203, 213, 225, 0.9);
+}
+
+.currency-readout__value {
+  font-size: 1.25rem;
   color: #fef3c7;
 }
 

--- a/routes/user.routes.js
+++ b/routes/user.routes.js
@@ -5,6 +5,7 @@ const {
   storyLanding,
   playNode,
   playEnding,
+  unlockChoice,
 } = require("../controllers/story.controller");
 
 const router = express.Router();
@@ -15,5 +16,9 @@ router.get("/stats", stats);
 router.get("/story/:id", storyLanding);
 router.get("/play/:id/:nodeId", playNode);
 router.get("/play/:id/ending/:endingId", playEnding);
+router.post(
+  "/story/:id/nodes/:nodeId/choices/:choiceId/unlock",
+  unlockChoice
+);
 
 module.exports = router;

--- a/views/admin/storyEditor.ejs
+++ b/views/admin/storyEditor.ejs
@@ -579,8 +579,17 @@
       transform: scale(1.05);
     }
 
+    .choice-field--label input {
+      max-width: 220px;
+    }
+
     .choice-field--cost input {
       text-align: right;
+      max-width: 120px;
+    }
+
+    .choice-field--cost {
+      justify-self: flex-start;
     }
 
     .choice-item.locked {
@@ -602,6 +611,13 @@
 
     .choice-form .choice-fields {
       background: rgba(17, 17, 17, 0.7);
+    }
+
+    @media (max-width: 640px) {
+      .choice-field--label input,
+      .choice-field--cost input {
+        max-width: 100%;
+      }
     }
 
     .empty-state {
@@ -780,7 +796,7 @@
         <div id="choice-list"></div>
         <form id="choice-add-form" class="choice-form">
           <div class="choice-fields">
-            <label class="choice-field">
+            <label class="choice-field choice-field--label">
               <span>Label</span>
               <input type="text" name="label" placeholder="Choice label" required>
             </label>
@@ -1114,7 +1130,7 @@
           fields.className = "choice-fields";
 
           const labelField = document.createElement("label");
-          labelField.className = "choice-field";
+          labelField.className = "choice-field choice-field--label";
           const labelSpan = document.createElement("span");
           labelSpan.textContent = "Label";
           const labelInput = document.createElement("input");

--- a/views/admin/storyEditor.ejs
+++ b/views/admin/storyEditor.ejs
@@ -181,6 +181,21 @@
       font-size: 0.82rem;
     }
 
+    .btn.icon-only {
+      padding: 0.35rem;
+      min-width: 2.25rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      line-height: 1;
+      font-weight: 600;
+    }
+
+    .btn.small.icon-only {
+      padding: 0.25rem 0.35rem;
+      font-size: 1.15rem;
+    }
+
     .btn:hover {
       background: rgba(255, 255, 255, 0.14);
     }
@@ -233,6 +248,14 @@
       display: flex;
       gap: 0.5rem;
       flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .map-zoom-controls {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      margin-right: 0.35rem;
     }
 
     .map-viewport {
@@ -264,6 +287,7 @@
       position: relative;
       min-width: 100%;
       min-height: 100%;
+      transform-origin: top left;
     }
 
     .map-links {
@@ -580,7 +604,7 @@
     }
 
     .choice-field--label input {
-      max-width: 220px;
+      max-width: 200px;
     }
 
     .choice-field--cost input {
@@ -738,6 +762,14 @@
       <div class="map-controls">
         <p>Drag passages into place. Connections redraw automatically with arrows indicating their direction.</p>
         <div class="map-controls-right">
+          <div class="map-zoom-controls" role="group" aria-label="Zoom map view">
+            <button type="button" class="btn small ghost icon-only" id="map-zoom-out-btn" aria-label="Zoom out">
+              <span aria-hidden="true">&minus;</span>
+            </button>
+            <button type="button" class="btn small ghost icon-only" id="map-zoom-in-btn" aria-label="Zoom in">
+              <span aria-hidden="true">+</span>
+            </button>
+          </div>
           <button type="button" class="btn small" id="add-node-btn">+ Passage</button>
           <button type="button" class="btn small" id="add-ending-btn">+ Ending</button>
           <button type="button" class="btn small ghost" id="center-selection-btn">Center Selection</button>
@@ -866,6 +898,8 @@
       const addNodeBtn = document.getElementById("add-node-btn");
       const addEndingBtn = document.getElementById("add-ending-btn");
       const centerSelectionBtn = document.getElementById("center-selection-btn");
+      const zoomOutBtn = document.getElementById("map-zoom-out-btn");
+      const zoomInBtn = document.getElementById("map-zoom-in-btn");
       const categoryCheckboxes = Array.from(
         storyForm.querySelectorAll('input[name="categories"]')
       );
@@ -906,6 +940,11 @@
       const nodeColorSelect = nodeForm.elements.color;
 
       const elementIndex = new Map();
+      const MIN_MAP_SCALE = 0.6;
+      const MAX_MAP_SCALE = 1.8;
+      const MAP_SCALE_STEP = 0.2;
+
+      let mapScale = 1;
       let selected = null;
       let inspectorVisible = false;
       let drawFrame = null;
@@ -915,6 +954,40 @@
       let nodeDirty = false;
       let endingDirty = false;
       let selectionQueue = Promise.resolve();
+
+      const getViewportWidthInContent = (scale = mapScale) => {
+        if (!mapViewport) return 0;
+        const factor = scale > 0 ? scale : 1;
+        return mapViewport.clientWidth / factor;
+      };
+
+      const getViewportHeightInContent = (scale = mapScale) => {
+        if (!mapViewport) return 0;
+        const factor = scale > 0 ? scale : 1;
+        return mapViewport.clientHeight / factor;
+      };
+
+      const getViewportCenter = (scale = mapScale) => ({
+        x: mapViewport.scrollLeft + getViewportWidthInContent(scale) / 2,
+        y: mapViewport.scrollTop + getViewportHeightInContent(scale) / 2,
+      });
+
+      const applyMapScale = () => {
+        if (!mapCanvas) return;
+        mapCanvas.style.transform = `scale(${mapScale})`;
+      };
+
+      const updateZoomButtons = () => {
+        if (zoomOutBtn) {
+          zoomOutBtn.disabled = mapScale <= MIN_MAP_SCALE + 0.001;
+        }
+        if (zoomInBtn) {
+          zoomInBtn.disabled = mapScale >= MAX_MAP_SCALE - 0.001;
+        }
+      };
+
+      applyMapScale();
+      updateZoomButtons();
 
       const normalizeCollections = (story) => {
         story.nodes = Array.isArray(story.nodes) ? story.nodes : [];
@@ -1456,8 +1529,10 @@
         const entry = elementIndex.get(selected.id);
         if (!entry) return;
         const el = entry.element;
-        const x = el.offsetLeft + el.offsetWidth / 2 - mapViewport.clientWidth / 2;
-        const y = el.offsetTop + el.offsetHeight / 2 - mapViewport.clientHeight / 2;
+        const viewportWidth = getViewportWidthInContent();
+        const viewportHeight = getViewportHeightInContent();
+        const x = el.offsetLeft + el.offsetWidth / 2 - viewportWidth / 2;
+        const y = el.offsetTop + el.offsetHeight / 2 - viewportHeight / 2;
         mapViewport.scrollTo({
           left: Math.max(x, 0),
           top: Math.max(y, 0),
@@ -1471,6 +1546,28 @@
           drawFrame = null;
           drawLinks();
         });
+      };
+
+      const changeMapScale = (delta) => {
+        if (!mapViewport) return;
+        const proposed = Math.round((mapScale + delta) * 100) / 100;
+        const nextScale = Math.min(
+          MAX_MAP_SCALE,
+          Math.max(MIN_MAP_SCALE, proposed)
+        );
+        if (nextScale === mapScale) return;
+        const previousScale = mapScale;
+        const previousCenter = getViewportCenter(previousScale);
+        mapScale = nextScale;
+        applyMapScale();
+        updateZoomButtons();
+        const nextWidth = getViewportWidthInContent();
+        const nextHeight = getViewportHeightInContent();
+        mapViewport.scrollTo({
+          left: Math.max(previousCenter.x - nextWidth / 2, 0),
+          top: Math.max(previousCenter.y - nextHeight / 2, 0),
+        });
+        scheduleDrawLinks();
       };
 
       const drawLinks = () => {
@@ -1669,6 +1766,7 @@
         highlightSelection();
         drawLinks();
         initDrag();
+        applyMapScale();
       };
 
       const setStoryData = (newStory) => {
@@ -1689,8 +1787,10 @@
           listeners: {
             move(event) {
               const target = event.target;
-              const x = (parseFloat(target.dataset.x) || 0) + event.dx;
-              const y = (parseFloat(target.dataset.y) || 0) + event.dy;
+              const deltaX = event.dx / (mapScale || 1);
+              const deltaY = event.dy / (mapScale || 1);
+              const x = (parseFloat(target.dataset.x) || 0) + deltaX;
+              const y = (parseFloat(target.dataset.y) || 0) + deltaY;
               target.dataset.x = x;
               target.dataset.y = y;
               target.style.left = `${x}px`;
@@ -1753,9 +1853,10 @@
       addNodeBtn.addEventListener("click", () => {
         queueTask(async () => {
           await flushPendingChanges(selected ? { ...selected } : null);
+          const center = getViewportCenter();
           const position = {
-            x: mapViewport.scrollLeft + mapViewport.clientWidth / 2 - 110,
-            y: mapViewport.scrollTop + mapViewport.clientHeight / 2 - 80,
+            x: center.x - 110,
+            y: center.y - 80,
           };
           const data = await postJSON(`/admin/stories/${storyId}/nodes/add`, { position });
           const newNode = data.story.nodes && data.story.nodes[0];
@@ -1772,9 +1873,10 @@
       addEndingBtn.addEventListener("click", () => {
         queueTask(async () => {
           await flushPendingChanges(selected ? { ...selected } : null);
+          const center = getViewportCenter();
           const position = {
-            x: mapViewport.scrollLeft + mapViewport.clientWidth / 2 - 110,
-            y: mapViewport.scrollTop + mapViewport.clientHeight / 2 - 80,
+            x: center.x - 110,
+            y: center.y - 80,
           };
           const data = await postJSON(`/admin/stories/${storyId}/endings/add`, { position });
           const newEnding = data.story.endings && data.story.endings[0];
@@ -1787,6 +1889,18 @@
           }
         });
       });
+
+      if (zoomOutBtn) {
+        zoomOutBtn.addEventListener("click", () => {
+          changeMapScale(-MAP_SCALE_STEP);
+        });
+      }
+
+      if (zoomInBtn) {
+        zoomInBtn.addEventListener("click", () => {
+          changeMapScale(MAP_SCALE_STEP);
+        });
+      }
 
       centerSelectionBtn.addEventListener("click", () => {
         centerOnSelected();

--- a/views/admin/storyEditor.ejs
+++ b/views/admin/storyEditor.ejs
@@ -430,6 +430,19 @@
       stroke: rgba(255, 139, 92, 0.7);
     }
 
+    .link.locked {
+      stroke: rgba(250, 204, 21, 0.9);
+      stroke-width: 3.2;
+      stroke-dasharray: 6 4;
+    }
+
+    .link-lock-icon {
+      font-size: 1rem;
+      fill: rgba(250, 204, 21, 0.9);
+      pointer-events: none;
+      text-shadow: 0 0 6px rgba(0, 0, 0, 0.45);
+    }
+
     .entity-editor {
       position: fixed;
       right: 2rem;
@@ -515,12 +528,13 @@
 
     .choice-fields {
       display: grid;
-      grid-template-columns: 1fr;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
       gap: 0.45rem;
       background: rgba(17, 17, 17, 0.7);
       border: 1px solid rgba(255, 255, 255, 0.06);
       border-radius: 10px;
       padding: 0.55rem 0.65rem;
+      align-items: end;
     }
 
     .choice-field {
@@ -547,6 +561,31 @@
       color: inherit;
       font: inherit;
       width: 100%;
+    }
+
+    .choice-field--toggle {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .choice-field--toggle span {
+      margin: 0;
+    }
+
+    .choice-field--toggle input[type="checkbox"] {
+      width: auto;
+      accent-color: #facc15;
+      transform: scale(1.05);
+    }
+
+    .choice-field--cost input {
+      text-align: right;
+    }
+
+    .choice-item.locked {
+      border-color: rgba(250, 204, 21, 0.35);
+      box-shadow: 0 0 0 1px rgba(250, 204, 21, 0.12) inset;
     }
 
     .choice-actions {
@@ -749,6 +788,14 @@
               <span>Next</span>
               <select name="nextNodeId" required></select>
             </label>
+            <label class="choice-field choice-field--toggle">
+              <span>Locked</span>
+              <input type="checkbox" name="locked" data-lock-toggle>
+            </label>
+            <label class="choice-field choice-field--cost">
+              <span>Unlock Cost</span>
+              <input type="number" name="unlockCost" min="0" step="1" value="0" data-lock-cost>
+            </label>
           </div>
           <div class="choice-actions">
             <button type="submit" class="btn small">Add Choice</button>
@@ -817,7 +864,26 @@
       const endingForm = document.getElementById("ending-form");
       const choiceList = document.getElementById("choice-list");
       const choiceAddForm = document.getElementById("choice-add-form");
+      const choiceAddLockToggle = choiceAddForm
+        ? choiceAddForm.querySelector("[data-lock-toggle]")
+        : null;
+      const choiceAddCostInput = choiceAddForm
+        ? choiceAddForm.querySelector("[data-lock-cost]")
+        : null;
       const choicesEmptyState = document.getElementById("choicesEmptyState");
+
+      const syncAddLockState = () => {
+        if (!choiceAddCostInput) return;
+        const locked = Boolean(choiceAddLockToggle?.checked);
+        choiceAddCostInput.disabled = !locked;
+        if (!locked) {
+          choiceAddCostInput.value = "0";
+        }
+      };
+      if (choiceAddLockToggle && choiceAddCostInput) {
+        syncAddLockState();
+        choiceAddLockToggle.addEventListener("change", syncAddLockState);
+      }
 
       const nodeEditorBlocks = entityEditor.querySelectorAll('[data-editor="node"]');
       const endingEditorBlocks = entityEditor.querySelectorAll('[data-editor="ending"]');
@@ -1040,6 +1106,9 @@
         node.choices.forEach((choice) => {
           const form = document.createElement("form");
           form.className = "choice-item";
+          if (choice.locked) {
+            form.classList.add("locked");
+          }
 
           const fields = document.createElement("div");
           fields.className = "choice-fields";
@@ -1065,8 +1134,34 @@
           selectField.appendChild(selectSpan);
           selectField.appendChild(select);
 
+          const lockedField = document.createElement("label");
+          lockedField.className = "choice-field choice-field--toggle";
+          const lockedSpan = document.createElement("span");
+          lockedSpan.textContent = "Locked";
+          const lockedInput = document.createElement("input");
+          lockedInput.type = "checkbox";
+          lockedInput.name = "locked";
+          lockedInput.checked = Boolean(choice.locked);
+          lockedField.appendChild(lockedSpan);
+          lockedField.appendChild(lockedInput);
+
+          const costField = document.createElement("label");
+          costField.className = "choice-field choice-field--cost";
+          const costSpan = document.createElement("span");
+          costSpan.textContent = "Unlock Cost";
+          const costInput = document.createElement("input");
+          costInput.type = "number";
+          costInput.name = "unlockCost";
+          costInput.min = "0";
+          costInput.step = "1";
+          costInput.value = Math.max(Number(choice.unlockCost) || 0, 0);
+          costField.appendChild(costSpan);
+          costField.appendChild(costInput);
+
           fields.appendChild(labelField);
           fields.appendChild(selectField);
+          fields.appendChild(lockedField);
+          fields.appendChild(costField);
           form.appendChild(fields);
 
           const actions = document.createElement("div");
@@ -1086,11 +1181,23 @@
 
           form.appendChild(actions);
 
+          const syncLockState = () => {
+            const isLocked = lockedInput.checked;
+            costInput.disabled = !isLocked;
+            form.classList.toggle("locked", isLocked);
+          };
+          syncLockState();
+          lockedInput.addEventListener("change", syncLockState);
+
           form.addEventListener("submit", (event) => {
             event.preventDefault();
             const payload = {
               label: labelInput.value,
               nextNodeId: select.value,
+              locked: lockedInput.checked,
+              unlockCost: lockedInput.checked
+                ? Math.max(Number(costInput.value) || 0, 0)
+                : 0,
             };
             queueTask(async () => {
               await flushPendingChanges(selected ? { ...selected } : null);
@@ -1393,6 +1500,7 @@
             const tx = toEl.offsetLeft + toEl.offsetWidth / 2;
             const ty = toEl.offsetTop + toEl.offsetHeight / 2;
             const midX = (fx + tx) / 2;
+            const midY = (fy + ty) / 2;
             const path = document.createElementNS(ns, "path");
             path.setAttribute("d", `M${fx},${fy} C${midX},${fy} ${midX},${ty} ${tx},${ty}`);
             path.classList.add("link");
@@ -1402,7 +1510,20 @@
             } else {
               path.setAttribute("marker-end", "url(#link-arrow)");
             }
+            if (choice.locked) {
+              path.classList.add("locked");
+            }
             frag.appendChild(path);
+            if (choice.locked) {
+              const lockIcon = document.createElementNS(ns, "text");
+              lockIcon.setAttribute("x", midX);
+              lockIcon.setAttribute("y", midY);
+              lockIcon.setAttribute("text-anchor", "middle");
+              lockIcon.setAttribute("dominant-baseline", "middle");
+              lockIcon.classList.add("link-lock-icon");
+              lockIcon.textContent = "🔒";
+              frag.appendChild(lockIcon);
+            }
           });
         });
         linkLayer.appendChild(frag);
@@ -1700,6 +1821,10 @@
         const payload = {
           label: choiceAddForm.elements.label.value,
           nextNodeId: choiceAddForm.elements.nextNodeId.value,
+          locked: Boolean(choiceAddLockToggle?.checked),
+          unlockCost: Boolean(choiceAddLockToggle?.checked)
+            ? Math.max(Number(choiceAddCostInput?.value) || 0, 0)
+            : 0,
         };
         queueTask(async () => {
           await flushPendingChanges(selected ? { ...selected } : null);
@@ -1710,6 +1835,13 @@
           selected = { type: "node", id: nodeId };
           choiceAddForm.reset();
           populateDestinationSelect(choiceAddForm.elements.nextNodeId, "");
+          if (choiceAddLockToggle) {
+            choiceAddLockToggle.checked = false;
+          }
+          if (choiceAddCostInput) {
+            choiceAddCostInput.value = "0";
+          }
+          syncAddLockState();
           setStoryData(data.story);
         });
       });

--- a/views/user/playNode.ejs
+++ b/views/user/playNode.ejs
@@ -15,16 +15,54 @@
 
       <p><%= node.text %></p>
 
+      <% if (feedback) { %>
+      <div class="notice notice--<%= feedback.type %>"><%= feedback.message %></div>
+      <% } %>
+
       <div class="choices">
-        <% node.choices.forEach(c => { const isEnding = story.endings.some(e =>
-        e._id === c.nextNodeId); const href = isEnding ?
-        `/u/play/${story._id}/ending/${c.nextNodeId}` :
-        `/u/play/${story._id}/${c.nextNodeId}`; %>
+        <% node.choices.forEach(function (c) { %>
+        <% const isEnding = story.endings.some(function (e) {
+             return e._id === c.nextNodeId;
+           });
+           const href = isEnding
+             ? `/u/play/${story._id}/ending/${c.nextNodeId}`
+             : `/u/play/${story._id}/${c.nextNodeId}`;
+           if (c.isLocked && !c.isUnlocked) {
+             const remaining = Math.max((c.unlockCost || 0) - (currency || 0), 0);
+             const disabled = currency < c.unlockCost;
+        %>
 
-        <a class="cta-button" href="<%= href %>"><%= c.label %></a>
+        <form
+          class="choice-unlock-form"
+          method="POST"
+          action="/u/story/<%= story._id %>/nodes/<%= node._id %>/choices/<%= c._id %>/unlock"
+        >
+          <button type="submit" class="cta-button locked" <%= disabled ? 'disabled' : '' %>>
+            <span class="choice-label">Unlock "<%= c.label %>"</span>
+            <span class="choice-cost">Cost: <%= c.unlockCost %></span>
+          </button>
+          <% if (disabled && c.unlockCost > 0) { %>
+          <p class="unlock-hint">You need <%= remaining %> more currency.</p>
+          <% } %>
+        </form>
 
-        <% }) %>
+        <% } else { %>
+        <a
+          class="cta-button <%= c.isLocked ? 'cta-button-unlocked' : '' %>"
+          href="<%= href %>"
+        >
+          <%= c.isLocked ? 'Unlocked: ' : '' %><%= c.label %>
+        </a>
+        <% } %>
+        <% }); %>
       </div>
+
+      <% if (hasLockedChoices) { %>
+      <div class="currency-readout">
+        <span>Your currency:</span>
+        <strong><%= currency || 0 %></strong>
+      </div>
+      <% } %>
     </main>
 
     <%- include('../partials/footer') %>

--- a/views/user/playNode.ejs
+++ b/views/user/playNode.ejs
@@ -37,30 +37,91 @@
           method="POST"
           action="/u/story/<%= story._id %>/nodes/<%= node._id %>/choices/<%= c._id %>/unlock"
         >
-          <button type="submit" class="cta-button locked" <%= disabled ? 'disabled' : '' %>>
-            <span class="choice-label">Unlock "<%= c.label %>"</span>
-            <span class="choice-cost">Cost: <%= c.unlockCost %></span>
+          <button
+            type="submit"
+            class="cta-button choice-button locked"
+            <%= disabled ? 'disabled' : '' %>
+            aria-label="Unlock &ldquo;<%= c.label %>&rdquo; for <%= c.unlockCost %> gems"
+          >
+            <span class="choice-main">
+              <span class="choice-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path
+                    fill="currentColor"
+                    d="M17 9h-1V7a4 4 0 0 0-8 0v2H7a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-9a2 2 0 0 0-2-2zm-7-2a2 2 0 0 1 4 0v2h-4V7zm7 13H7v-9h10z"
+                  />
+                </svg>
+              </span>
+              <span class="choice-label"><%= c.label %></span>
+            </span>
+            <span class="choice-cost">
+              <span class="icon icon-gem" aria-hidden="true">
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path
+                    fill="currentColor"
+                    d="M12 2 3 9l9 13 9-13-9-7zm0 3.2 3.9 3.3H8.1L12 5.2zm0 13.9-5.4-8.1h10.8L12 19.1z"
+                  />
+                </svg>
+              </span>
+              <span class="choice-cost-value"><%= c.unlockCost %></span>
+            </span>
           </button>
           <% if (disabled && c.unlockCost > 0) { %>
-          <p class="unlock-hint">You need <%= remaining %> more currency.</p>
+          <p class="unlock-hint">You need <%= remaining %> more gems.</p>
           <% } %>
         </form>
 
         <% } else { %>
         <a
-          class="cta-button <%= c.isLocked ? 'cta-button-unlocked' : '' %>"
+          class="cta-button choice-button <%= c.isLocked ? 'cta-button-unlocked' : '' %>"
           href="<%= href %>"
+          aria-label="<%= c.isLocked ? 'Unlocked choice: ' + c.label : c.label %>"
         >
-          <%= c.isLocked ? 'Unlocked: ' : '' %><%= c.label %>
+          <span class="choice-main">
+            <% if (c.isLocked) { %>
+            <span class="choice-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M17 9h-6V7a3 3 0 0 0-6 0v2h2V7a1 1 0 0 1 2 0v2H7a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-9a2 2 0 0 0-2-2zm0 11H7v-9h10z"
+                />
+              </svg>
+            </span>
+            <% } %>
+            <span class="choice-label"><%= c.label %></span>
+          </span>
+          <% if (c.isLocked && c.unlockCost > 0) { %>
+          <span class="choice-cost">
+            <span class="icon icon-gem" aria-hidden="true">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M12 2 3 9l9 13 9-13-9-7zm0 3.2 3.9 3.3H8.1L12 5.2zm0 13.9-5.4-8.1h10.8L12 19.1z"
+                />
+              </svg>
+            </span>
+            <span class="choice-cost-value"><%= c.unlockCost %></span>
+          </span>
+          <% } %>
         </a>
         <% } %>
         <% }); %>
       </div>
 
       <% if (hasLockedChoices) { %>
-      <div class="currency-readout">
-        <span>Your currency:</span>
-        <strong><%= currency || 0 %></strong>
+      <div class="currency-readout" aria-live="polite">
+        <span class="icon icon-gem" aria-hidden="true">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              fill="currentColor"
+              d="M12 2 3 9l9 13 9-13-9-7zm0 3.2 3.9 3.3H8.1L12 5.2zm0 13.9-5.4-8.1h10.8L12 19.1z"
+            />
+          </svg>
+        </span>
+        <div class="currency-readout__content">
+          <span class="currency-readout__label">Your gems</span>
+          <strong class="currency-readout__value"><%= currency || 0 %></strong>
+        </div>
       </div>
       <% } %>
     </main>

--- a/views/user/stats.ejs
+++ b/views/user/stats.ejs
@@ -6,79 +6,140 @@
   <body>
     <%- include('../partials/header', { user }) %>
 
-    <main class="container">
-      <h1 class="title">Player Stats</h1>
-      <p>Welcome, <%= dbUser.username %>!</p>
-
-      <!-- Summary Section -->
-      <section class="stats-summary">
-        <h2>Overview</h2>
-        <p>
-          <strong>Total Endings Found:</strong>
-          <%= dbUser.totalEndingsFound || 0 %>
+    <main class="stats-page">
+      <% const safeUser = dbUser || {}; %>
+      <% const statsOverview = overview || {}; %>
+      <% const trophyList = Array.isArray(trophies) ? trophies : []; %>
+      <% const requirementsList = Array.isArray(trophyRequirements) ? trophyRequirements : []; %>
+      <section class="stats-hero">
+        <h1>
+          Welcome back, <span><%= safeUser.username || "Adventurer" %></span>!
+        </h1>
+        <p class="stats-hero__tagline">
+          Your adventures shape the world. Track your progress, claim trophies,
+          and unlock new paths.
         </p>
-        <p>
-          <strong>Stories Completed:</strong>
-          <%= typeof storiesCompleted !== "undefined" ? storiesCompleted :
-          (dbUser.storiesRead || 0) %>
+        <div class="stats-hero__gems" aria-live="polite">
+          <span class="icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                fill="currentColor"
+                d="M12 2 3 9l9 13 9-13-9-7zm0 3.2 3.9 3.3H8.1L12 5.2zm0 13.9-5.4-8.1h10.8L12 19.1z"
+              />
+            </svg>
+          </span>
+          <div class="stats-hero__gems-info">
+            <span class="label">Your gems</span>
+            <span class="value"><%= typeof safeUser.currency === "number" ? safeUser.currency : 0 %></span>
+          </div>
+        </div>
+        <p class="stats-hero__hint">
+          Earn more gems by finding endings and earning trophies.
         </p>
-        <p><strong>Currency:</strong> <%= dbUser.currency || 0 %> 🪙</p>
       </section>
 
-      <!-- Medals Section -->
-      <section class="medals">
-        <h2>Medals</h2>
-        <p>
-          <strong>Death Endings Medal:</strong>
-          <%= dbUser.medals?.death ? dbUser.medals.death.toUpperCase() : "None"
-          %>
-        </p>
-        <p>
-          <strong>True Endings Medal:</strong>
-          <%= dbUser.medals?.trueEnding ? dbUser.medals.trueEnding.toUpperCase()
-          : "None" %>
-        </p>
-
-        <!-- Medal Requirements -->
-        <div class="medal-legend">
-          <h3>Medal Requirements</h3>
-          <div class="medal-group">
-            <h4>💀 Death Endings Medal</h4>
-            <ul>
-              <li>Bronze: 1+ death ending found</li>
-              <li>Silver: 5+ death endings</li>
-              <li>Gold: 10+ death endings</li>
-              <li>Platinum: 20+ death endings</li>
-            </ul>
-          </div>
-
-          <div class="medal-group">
-            <h4>✨ True Endings Medal</h4>
-            <ul>
-              <li>Bronze: 1+ story with a true ending</li>
-              <li>Silver: 3+ stories with true endings</li>
-              <li>Gold: 5+ stories with true endings</li>
-              <li>Platinum: 10+ stories with true endings</li>
-            </ul>
-          </div>
+      <section class="stats-section">
+        <div class="section-header">
+          <h2>Overview</h2>
+          <p>Highlights from your journey so far.</p>
+        </div>
+        <div class="overview-grid">
+          <article class="overview-card">
+            <span class="overview-label">Total endings found</span>
+            <span class="overview-value"><%= typeof statsOverview.totalEndingsFound === "number" ? statsOverview.totalEndingsFound : 0 %></span>
+          </article>
+          <article class="overview-card">
+            <span class="overview-label">Stories started</span>
+            <span class="overview-value"><%= typeof statsOverview.storiesStarted === "number" ? statsOverview.storiesStarted : 0 %></span>
+          </article>
+          <article class="overview-card">
+            <span class="overview-label">Stories created</span>
+            <span class="overview-value"><%= typeof statsOverview.storiesCreated === "number" ? statsOverview.storiesCreated : 0 %></span>
+            <span class="overview-caption">Tracking coming soon</span>
+          </article>
+          <article class="overview-card">
+            <span class="overview-label">True endings found</span>
+            <span class="overview-value"><%= typeof statsOverview.trueEndingsFound === "number" ? statsOverview.trueEndingsFound : 0 %></span>
+          </article>
+          <article class="overview-card">
+            <span class="overview-label">Death endings found</span>
+            <span class="overview-value"><%= typeof statsOverview.deathEndingsFound === "number" ? statsOverview.deathEndingsFound : 0 %></span>
+          </article>
+          <article class="overview-card">
+            <span class="overview-label">Secret endings found</span>
+            <span class="overview-value"><%= typeof statsOverview.secretEndingsFound === "number" ? statsOverview.secretEndingsFound : 0 %></span>
+          </article>
+          <article class="overview-card">
+            <span class="overview-label">Paths unlocked</span>
+            <span class="overview-value"><%= typeof statsOverview.pathsUnlocked === "number" ? statsOverview.pathsUnlocked : 0 %></span>
+          </article>
         </div>
       </section>
 
-      <!-- Story Progress Section -->
-      <section class="progress">
-        <h2>Stories Progress</h2>
-        <% if (dbUser && Array.isArray(dbUser.progress) &&
-        dbUser.progress.length) { %>
-        <ul>
-          <% dbUser.progress.forEach(function(p) { %>
+      <section class="stats-section">
+        <div class="section-header">
+          <h2>Trophies</h2>
+          <p>Collect shimmering trophies by mastering different playstyles.</p>
+        </div>
+        <div class="trophy-grid">
+          <% trophyList.forEach(function (trophy) { %>
+          <% const levelClass = trophy.level ? `level-${trophy.level}` : 'level-none'; %>
+          <article class="trophy-card <%= levelClass %>">
+            <div class="trophy-icon" aria-hidden="true">
+              <svg viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M20 8h24v6h8a2 2 0 0 1 2 2c0 10.5-7.13 19.24-17 21.53V44h7v6H20v-6h7v-6.47C17.13 35.24 10 26.5 10 16a2 2 0 0 1 2-2h8V8zm-6 8c.3 7.4 4.75 13.73 11 16.08V16H14zm36 0H39v16.08c6.25-2.35 10.7-8.68 11-16.08z"
+                />
+                <rect x="24" y="44" width="16" height="6" fill="currentColor" />
+                <rect x="22" y="50" width="20" height="6" fill="currentColor" />
+              </svg>
+            </div>
+            <h3><%= trophy.label %></h3>
+            <p class="trophy-level"><%= trophy.levelLabel %></p>
+            <p class="trophy-progress"><%= trophy.progressText %></p>
+          </article>
+          <% }) %>
+        </div>
+      </section>
+
+      <section class="stats-section">
+        <div class="section-header">
+          <h2>Trophy Requirements</h2>
+          <p>Level up each trophy by meeting these milestones.</p>
+        </div>
+        <div class="requirements-grid">
+          <% requirementsList.forEach(function (req) { %>
+          <article class="requirement-card">
+            <h3><%= req.label %></h3>
+            <ul>
+              <% req.requirements.forEach(function (line) { %>
+              <li><%= line %></li>
+              <% }) %>
+            </ul>
+          </article>
+          <% }) %>
+        </div>
+      </section>
+
+      <section class="stats-section">
+        <div class="section-header">
+          <h2>Story Progress</h2>
+          <p>See how many endings you've uncovered in each tale.</p>
+        </div>
+        <% if (safeUser && Array.isArray(safeUser.progress) && safeUser.progress.length) { %>
+        <ul class="progress-list">
+          <% safeUser.progress.forEach(function(p) { %>
           <li>
-            <strong>
-              <%= (p.story && p.story.title) ? p.story.title : "Untitled Story"
-              %>
-            </strong>
-            — <%= (Array.isArray(p.endingsFound)) ? p.endingsFound.length : 0 %>
-            / <%= (p.story && Array.isArray(p.story.endings)) ?
-            p.story.endings.length : 0 %> endings found
+            <div class="progress-story">
+              <strong><%= (p.story && p.story.title) ? p.story.title : "Untitled Story" %></strong>
+              <span class="progress-endings">
+                <%= (Array.isArray(p.endingsFound)) ? p.endingsFound.length : 0 %>
+                /
+                <%= (p.story && Array.isArray(p.story.endings)) ? p.story.endings.length : 0 %>
+                endings found
+              </span>
+            </div>
           </li>
           <% }) %>
         </ul>
@@ -91,51 +152,290 @@
     <%- include('../partials/footer') %>
 
     <style>
-      main.container {
-        max-width: 800px;
+      .stats-page {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 2.5rem 1.5rem 3rem;
+        display: flex;
+        flex-direction: column;
+        gap: 2.5rem;
       }
 
-      section {
-        margin-bottom: 2rem;
+      .stats-hero {
+        background: linear-gradient(135deg, rgba(99, 102, 241, 0.25), rgba(236, 72, 153, 0.2));
+        border: 1px solid rgba(129, 140, 248, 0.35);
+        border-radius: 20px;
+        padding: 2.25rem 2.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.2rem;
+        box-shadow: 0 24px 45px rgba(79, 70, 229, 0.2);
       }
 
-      h2,
-      h3,
-      h4 {
-        margin-bottom: 0.5rem;
+      .stats-hero h1 {
+        margin: 0;
+        font-size: 2.4rem;
+        font-weight: 700;
+        letter-spacing: 0.02em;
       }
 
-      .stats-summary p,
-      .medals p,
-      .progress p {
+      .stats-hero h1 span {
+        color: #c4b5fd;
+      }
+
+      .stats-hero__tagline {
+        margin: 0;
+        font-size: 1.05rem;
+        color: rgba(226, 232, 240, 0.9);
+        max-width: 560px;
+      }
+
+      .stats-hero__gems {
+        display: inline-flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 0.85rem 1.2rem;
+        border-radius: 14px;
+        background: rgba(15, 23, 42, 0.55);
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        width: fit-content;
+      }
+
+      .stats-hero__gems .icon svg {
+        width: 2.1rem;
+        height: 2.1rem;
+        color: #fcd34d;
+      }
+
+      .stats-hero__gems-info {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+      }
+
+      .stats-hero__gems-info .label {
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(203, 213, 225, 0.85);
+      }
+
+      .stats-hero__gems-info .value {
+        font-size: 1.6rem;
+        font-weight: 700;
+        color: #fef3c7;
+      }
+
+      .stats-hero__hint {
+        margin: 0;
+        font-size: 0.95rem;
+        color: rgba(226, 232, 240, 0.82);
+      }
+
+      .stats-section {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+
+      .section-header h2 {
+        margin: 0;
+        font-size: 1.4rem;
+        letter-spacing: 0.04em;
+      }
+
+      .section-header p {
+        margin: 0.35rem 0 0;
+        color: rgba(148, 163, 184, 0.85);
+        font-size: 0.95rem;
+      }
+
+      .overview-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1rem;
+      }
+
+      .overview-card {
+        background: rgba(15, 23, 42, 0.65);
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        border-radius: 16px;
+        padding: 1.1rem 1.25rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+      }
+
+      .overview-label {
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: rgba(203, 213, 225, 0.75);
+      }
+
+      .overview-value {
+        font-size: 1.8rem;
+        font-weight: 700;
+        color: #f8fafc;
+      }
+
+      .overview-caption {
+        font-size: 0.75rem;
+        color: rgba(148, 163, 184, 0.7);
+      }
+
+      .trophy-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1.5rem;
+      }
+
+      .trophy-card {
+        background: rgba(30, 41, 59, 0.65);
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        border-radius: 18px;
+        padding: 1.4rem 1.25rem 1.5rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 0.75rem;
+        transition: transform 0.2s ease;
+      }
+
+      .trophy-card:hover {
+        transform: translateY(-4px);
+      }
+
+      .trophy-icon svg {
+        width: 68px;
+        height: 68px;
+      }
+
+      .trophy-card h3 {
+        margin: 0;
+        font-size: 1.1rem;
+        letter-spacing: 0.02em;
+      }
+
+      .trophy-level {
+        margin: 0;
+        font-size: 0.9rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(226, 232, 240, 0.75);
+      }
+
+      .trophy-progress {
+        margin: 0;
+        font-size: 0.95rem;
+        color: rgba(226, 232, 240, 0.85);
+      }
+
+      .trophy-card.level-none .trophy-icon svg {
+        color: rgba(148, 163, 184, 0.5);
+      }
+
+      .trophy-card.level-bronze .trophy-icon svg {
+        color: #cd7f32;
+      }
+
+      .trophy-card.level-silver .trophy-icon svg {
+        color: #c0c0c0;
+      }
+
+      .trophy-card.level-gold .trophy-icon svg {
+        color: #ffd700;
+      }
+
+      .trophy-card.level-platinum .trophy-icon svg {
+        color: #e5e4e2;
+      }
+
+      .requirements-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1.25rem;
+      }
+
+      .requirement-card {
+        background: rgba(15, 23, 42, 0.65);
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        border-radius: 16px;
+        padding: 1.25rem 1.4rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.65rem;
+      }
+
+      .requirement-card h3 {
+        margin: 0;
+        font-size: 1.05rem;
+        color: #e2e8f0;
+      }
+
+      .requirement-card ul {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        color: rgba(203, 213, 225, 0.85);
+      }
+
+      .progress-list {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 0.8rem;
+      }
+
+      .progress-list li {
+        background: rgba(15, 23, 42, 0.6);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: 12px;
+        padding: 0.85rem 1.1rem;
+      }
+
+      .progress-story {
+        display: flex;
+        flex-direction: column;
+        gap: 0.3rem;
+      }
+
+      .progress-story strong {
         font-size: 1rem;
-        margin: 0.3rem 0;
+        letter-spacing: 0.02em;
       }
 
-      .medal-legend {
-        margin-top: 1rem;
-        padding: 1rem;
-        border: 1px solid #555;
-        border-radius: 10px;
-        background: #777;
-      }
-
-      .medal-group {
-        margin-top: 1rem;
-      }
-
-      .medal-group h4 {
-        margin-bottom: 0.3rem;
-      }
-
-      .medal-group ul {
-        list-style: disc;
-        margin-left: 1.5rem;
+      .progress-endings {
+        font-size: 0.9rem;
+        color: rgba(148, 163, 184, 0.85);
       }
 
       .muted {
-        color: #777;
+        color: rgba(148, 163, 184, 0.7);
         font-style: italic;
+      }
+
+      @media (max-width: 720px) {
+        .stats-hero {
+          padding: 1.75rem 1.5rem;
+        }
+
+        .stats-hero h1 {
+          font-size: 2rem;
+        }
+
+        .overview-grid {
+          grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        }
+
+        .trophy-grid {
+          grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        }
       }
     </style>
   </body>

--- a/views/user/storyLanding.ejs
+++ b/views/user/storyLanding.ejs
@@ -57,6 +57,12 @@
         </a>
         <% } %>
       </div>
+      <% if (lockedPaths && lockedPaths.total > 0) { %>
+      <p class="locked-path-summary">
+        This story has <%= lockedPaths.total %> locked paths in it. You have
+        unlocked:<%= lockedPaths.unlocked %>.
+      </p>
+      <% } %>
     </main>
 
     <%- include('../partials/footer') %>
@@ -128,6 +134,12 @@
 
       .cta-button.ghost:hover {
         background: rgba(148, 163, 184, 0.12);
+      }
+
+      .locked-path-summary {
+        margin-top: 2.5rem;
+        font-size: 0.85rem;
+        color: rgba(148, 163, 184, 0.85);
       }
     </style>
   </body>

--- a/views/user/storyLanding.ejs
+++ b/views/user/storyLanding.ejs
@@ -60,7 +60,7 @@
       <% if (lockedPaths && lockedPaths.total > 0) { %>
       <p class="locked-path-summary">
         This story has <%= lockedPaths.total %> locked paths in it. You have
-        unlocked:<%= lockedPaths.unlocked %>.
+        unlocked: <%= lockedPaths.unlocked %>
       </p>
       <% } %>
     </main>


### PR DESCRIPTION
## Summary
- add lock state and currency costs to story choices with per-user unlock tracking
- update the admin story editor to configure locked choices and visualize them on the map
- refresh player-facing pages to handle unlocking, show currency, and call out locked path counts

## Testing
- npm run dev *(fails: MongoDB connection is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e706e4fa048332b12c92ead8c42c5b