### PR TITLE
Add author workflow and dual-currency support

### DIFF
--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -126,6 +126,13 @@ const parseStoryPayload = (body = {}) => {
         ? node.color.trim()
         : "twilight";
 
+    const positionX = Number(node?.position?.x ?? node?.position?.X ?? node?.posX);
+    const positionY = Number(node?.position?.y ?? node?.position?.Y ?? node?.posY);
+    const position = {
+      x: Number.isFinite(positionX) ? positionX : 0,
+      y: Number.isFinite(positionY) ? positionY : 0,
+    };
+
     const rawChoices = normalizeToArray(node?.choices);
     const choices = [];
 
@@ -174,6 +181,7 @@ const parseStoryPayload = (body = {}) => {
       image,
       notes: nodeNotes,
       color,
+      position,
       choices,
     });
   });
@@ -212,7 +220,21 @@ const parseStoryPayload = (body = {}) => {
     const endingNotes =
       typeof ending?.notes === "string" ? ending.notes.trim() : "";
 
-    endings.push({ _id: id, label, type, text, notes: endingNotes });
+    const endPosX = Number(ending?.position?.x ?? ending?.position?.X ?? ending?.posX);
+    const endPosY = Number(ending?.position?.y ?? ending?.position?.Y ?? ending?.posY);
+    const endingPosition = {
+      x: Number.isFinite(endPosX) ? endPosX : 0,
+      y: Number.isFinite(endPosY) ? endPosY : 0,
+    };
+
+    endings.push({
+      _id: id,
+      label,
+      type,
+      text,
+      notes: endingNotes,
+      position: endingPosition,
+    });
   });
 
   if (!nodes.length) {
@@ -265,6 +287,10 @@ const prepareStoryFormData = (story = {}) => ({
         image: node.image || "",
         notes: node.notes || "",
         color: node.color || "twilight",
+        position: {
+          x: Number(node.position?.x) || 0,
+          y: Number(node.position?.y) || 0,
+        },
         choices: Array.isArray(node.choices)
           ? node.choices.map((choice) => ({
               _id: choice._id || "",
@@ -283,6 +309,10 @@ const prepareStoryFormData = (story = {}) => ({
         type: ending.type || "other",
         text: ending.text || "",
         notes: ending.notes || "",
+        position: {
+          x: Number(ending.position?.x) || 0,
+          y: Number(ending.position?.y) || 0,
+        },
       }))
     : [],
 });

--- a/models/story.model.js
+++ b/models/story.model.js
@@ -47,8 +47,20 @@ const storySchema = new mongoose.Schema(
     coverImage: String,
     status: {
       type: String,
-      enum: ["public", "coming_soon", "invisible"],
+      enum: [
+        "public",
+        "coming_soon",
+        "invisible",
+        "private",
+        "pending",
+        "under_review",
+      ],
       default: "invisible",
+    },
+    origin: {
+      type: String,
+      enum: ["official", "user"],
+      default: "official",
     },
     startNodeId: { type: String, default: null },
     author: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
@@ -62,6 +74,8 @@ const storySchema = new mongoose.Schema(
 
     images: { type: [require("mongoose").Schema.Types.Mixed], default: [] },
     displayOrder: { type: Number, default: 0 },
+    submittedAt: { type: Date },
+    publishedAt: { type: Date },
   },
   { timestamps: true }
 );

--- a/models/story.model.js
+++ b/models/story.model.js
@@ -66,6 +66,7 @@ const storySchema = new mongoose.Schema(
     author: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
 
     notes: String,
+    reviewNote: { type: String, default: "" },
 
     categories: { type: [String], default: [] },
 

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -37,6 +37,7 @@ const userSchema = new mongoose.Schema(
 
     // Currency system
     currency: { type: Number, default: 0 },
+    authorCurrency: { type: Number, default: 0 },
   },
   { timestamps: true }
 );

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -38,6 +38,23 @@ const userSchema = new mongoose.Schema(
     // Currency system
     currency: { type: Number, default: 0 },
     authorCurrency: { type: Number, default: 0 },
+    trophies: {
+      storyBuilder: {
+        type: String,
+        enum: ["none", "bronze", "silver", "gold", "platinum"],
+        default: "none",
+      },
+      publishedAuthor: {
+        type: String,
+        enum: ["none", "bronze", "silver", "gold", "platinum"],
+        default: "none",
+      },
+      communityReader: {
+        type: String,
+        enum: ["none", "bronze", "silver", "gold", "platinum"],
+        default: "none",
+      },
+    },
   },
   { timestamps: true }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "mongoose": "^8.18.2",
         "multer": "^2.0.2",
         "multer-storage-cloudinary": "^4.0.0",
-        "nodemailer": "^7.0.7",
         "nodemon": "^3.1.10"
       }
     },
@@ -1571,15 +1570,6 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/nodemailer": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.7.tgz",
-      "integrity": "sha512-jGOaRznodf62TVzdyhKt/f1Q/c3kYynk8629sgJHpRzGZj01ezbgMMWJSAjHADcwTKxco3B68/R+KHJY2T5BaA==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "mongoose": "^8.18.2",
     "multer": "^2.0.2",
     "multer-storage-cloudinary": "^4.0.0",
-    "nodemailer": "^7.0.7",
     "nodemon": "^3.1.10"
   }
 }

--- a/public/css/authorBuilder.css
+++ b/public/css/authorBuilder.css
@@ -1,0 +1,664 @@
+:root {
+  --panel-bg: #111;
+  --panel-border: #232323;
+  --panel-shadow: 0 24px 55px rgba(0, 0, 0, 0.45);
+  --accent: #6c5ce7;
+  --accent-2: #45aaf2;
+  --danger: #ff6b6b;
+  --map-grid: rgba(255, 255, 255, 0.06);
+}
+
+body {
+  background: #080808;
+  color: #f5f5f5;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  overflow-x: hidden;
+}
+
+.story-editor-shell {
+  width: 100%;
+  padding: 1.5rem 2rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: calc(100vh - 70px);
+  max-width: 1280px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 18px;
+  box-shadow: var(--panel-shadow);
+  padding: 1.25rem 1.5rem;
+}
+
+.editor-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.toolbar-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.editor-toolbar h1 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.toolbar-group {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.story-details-panel h2 {
+  margin-top: 0;
+  font-size: 1.2rem;
+}
+
+.story-details-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem 1.25rem;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.field > span {
+  color: #b9b9b9;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.field input,
+.field select,
+.field textarea {
+  width: 100%;
+  background: rgba(30, 30, 30, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: inherit;
+  border-radius: 10px;
+  padding: 0.55rem 0.7rem;
+  font: inherit;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.field textarea {
+  min-height: 110px;
+}
+
+.field.field--wide {
+  grid-column: 1 / -1;
+}
+
+.field.field--multiline textarea {
+  min-height: 140px;
+  background: rgba(24, 24, 24, 0.95);
+}
+
+.field select option,
+.choice-field select option {
+  background: #1f1f1f;
+  color: #f5f5f5;
+}
+
+.field.field--tags {
+  gap: 0.65rem;
+}
+
+.tag-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.tag-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(26, 26, 26, 0.92);
+  font-size: 0.82rem;
+  letter-spacing: 0.01em;
+}
+
+.tag-option input[type="checkbox"] {
+  accent-color: var(--accent);
+}
+
+.tag-option span {
+  pointer-events: none;
+}
+
+.btn {
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.45rem 1.05rem;
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.btn.small {
+  padding: 0.35rem 0.85rem;
+  font-size: 0.82rem;
+}
+
+.btn.icon-only {
+  padding: 0.35rem;
+  min-width: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  font-weight: 600;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.btn.ghost {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.btn:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.btn.primary:hover {
+  background: linear-gradient(135deg, #8e7bff, #5ec0ff);
+}
+
+.btn.danger {
+  background: rgba(255, 107, 107, 0.12);
+  border-color: rgba(255, 107, 107, 0.6);
+  color: #ffb3b3;
+}
+
+.btn.danger:hover {
+  background: rgba(255, 107, 107, 0.24);
+}
+
+.map-panel {
+  display: flex;
+  flex-direction: column;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 22px;
+  box-shadow: var(--panel-shadow);
+  overflow: hidden;
+  min-height: 540px;
+  max-width: 100%;
+  width: 100%;
+}
+
+.map-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--panel-border);
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.map-controls p {
+  margin: 0;
+  color: #b3b3b3;
+  font-size: 0.92rem;
+}
+
+.map-controls-right {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.map-zoom-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-right: 0.35rem;
+}
+
+.map-viewport {
+  position: relative;
+  flex: 1;
+  overflow: auto;
+  background: #040404;
+  background-image: linear-gradient(transparent 49px, var(--map-grid) 50px),
+    linear-gradient(90deg, transparent 49px, var(--map-grid) 50px);
+  background-size: 50px 50px;
+  max-width: 100%;
+}
+
+.map-viewport::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+.map-viewport::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.22);
+  border-radius: 8px;
+}
+
+.map-viewport::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.map-canvas {
+  position: relative;
+  min-width: 100%;
+  min-height: 100%;
+  transform-origin: top left;
+}
+
+.map-links {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.map-node {
+  position: absolute;
+  width: 230px;
+  min-height: 110px;
+  padding: 0.95rem 1.1rem 1.1rem;
+  border-radius: 14px;
+  border: 2.5px solid rgba(255, 255, 255, 0.12);
+  background: rgba(18, 18, 18, 0.8);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.4);
+  cursor: grab;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  transition: box-shadow 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+  --accent-color: rgba(108, 92, 231, 1);
+  --accent-border: rgba(108, 92, 231, 0.55);
+  --accent-shadow: rgba(108, 92, 231, 0.35);
+  z-index: 1;
+}
+
+.map-node:active {
+  cursor: grabbing;
+}
+
+.map-node.selected {
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.55), 0 0 0 2px rgba(255, 255, 255, 0.2);
+}
+
+.map-node.color-twilight {
+  --accent-color: #7c6cff;
+  --accent-border: rgba(124, 108, 255, 0.65);
+  --accent-shadow: rgba(124, 108, 255, 0.35);
+}
+
+.map-node.color-ember {
+  --accent-color: #ff8b5c;
+  --accent-border: rgba(255, 139, 92, 0.68);
+  --accent-shadow: rgba(255, 139, 92, 0.36);
+}
+
+.map-node.color-moss {
+  --accent-color: #55efc4;
+  --accent-border: rgba(85, 239, 196, 0.6);
+  --accent-shadow: rgba(85, 239, 196, 0.33);
+}
+
+.map-node.color-dusk {
+  --accent-color: #45aaf2;
+  --accent-border: rgba(69, 170, 242, 0.62);
+  --accent-shadow: rgba(69, 170, 242, 0.34);
+}
+
+map-node.color-rose {
+  --accent-color: #ff6bcb;
+  --accent-border: rgba(255, 107, 203, 0.62);
+  --accent-shadow: rgba(255, 107, 203, 0.34);
+}
+
+.map-node.color-slate {
+  --accent-color: #b2bec3;
+  --accent-border: rgba(178, 190, 195, 0.52);
+  --accent-shadow: rgba(178, 190, 195, 0.28);
+}
+
+.map-node:not(.ending) {
+  border-color: var(--accent-color);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45), 0 0 0 2px var(--accent-shadow);
+}
+
+.map-node.start-node {
+  border-color: var(--accent-color);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55), 0 0 0 3px var(--accent-color);
+}
+
+.map-node .node-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.node-title .node-id {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.node-title .image-flag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.16);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.72rem;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.2);
+}
+
+.node-snippet {
+  font-size: 0.82rem;
+  line-height: 1.35;
+  color: #e0e0e0;
+  max-height: 70px;
+  overflow: hidden;
+}
+
+.node-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #a2a2a2;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.map-node.ending {
+  background: rgba(255, 255, 255, 0.08);
+  border: 2px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.4);
+}
+
+.map-node.ending .node-meta {
+  justify-content: flex-end;
+}
+
+.link {
+  fill: none;
+  stroke: rgba(108, 92, 231, 0.65);
+  stroke-width: 2.5px;
+}
+
+.link.to-ending {
+  stroke: rgba(255, 139, 92, 0.8);
+}
+
+.link.locked {
+  stroke-dasharray: 6 4;
+}
+
+.link-lock-icon {
+  font-size: 0.9rem;
+  fill: rgba(250, 204, 21, 0.9);
+}
+
+.entity-editor {
+  position: fixed;
+  right: 2rem;
+  top: 6.5rem;
+  width: 360px;
+  max-height: calc(100vh - 7rem);
+  display: flex;
+  flex-direction: column;
+  background: rgba(10, 10, 10, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 18px;
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+  z-index: 30;
+}
+
+.entity-editor.hidden {
+  display: none;
+}
+
+.entity-editor.collapsed .entity-editor__body {
+  display: none;
+}
+
+.entity-editor__header {
+  padding: 1rem 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.entity-editor__header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.entity-editor__subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: #b9b9b9;
+}
+
+.entity-editor__body {
+  padding: 1rem 1.2rem 1.4rem;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.choices-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.choice-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem 0.65rem;
+}
+
+.choice-item.locked {
+  border-color: rgba(250, 204, 21, 0.35);
+  box-shadow: 0 0 0 1px rgba(250, 204, 21, 0.12) inset;
+}
+
+.choice-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.45rem;
+  background: rgba(17, 17, 17, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 0.55rem 0.65rem;
+  align-items: end;
+}
+
+.choice-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: #cfd2ff;
+}
+
+.choice-field span {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: #c7c7c7;
+}
+
+.choice-field--toggle {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.choice-field--cost input {
+  text-align: right;
+  max-width: 120px;
+}
+
+.choice-actions {
+  display: flex;
+  gap: 0.35rem;
+  justify-content: flex-end;
+}
+
+.choice-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.muted {
+  color: #b0b0b0;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.flash {
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+}
+
+.flash-error {
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  background: rgba(248, 113, 113, 0.12);
+  color: #fecaca;
+}
+
+.story-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: #e2e8f0;
+  background: rgba(148, 163, 184, 0.12);
+  width: fit-content;
+}
+
+.story-status-public {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: rgba(34, 197, 94, 0.32);
+  color: #bbf7d0;
+}
+
+.story-status-pending,
+.story-status-coming_soon {
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.32);
+  color: #c7d2fe;
+}
+
+.story-status-under_review {
+  background: rgba(244, 114, 182, 0.18);
+  border-color: rgba(244, 114, 182, 0.32);
+  color: #fbcfe8;
+}
+
+.story-status-private {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: rgba(148, 163, 184, 0.32);
+}
+
+.story-status-public strong,
+.story-status-pending strong,
+.story-status-under_review strong {
+  color: inherit;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 1100px) {
+  .entity-editor {
+    position: fixed;
+    width: calc(100% - 3rem);
+    right: 1.5rem;
+    top: auto;
+    bottom: 1.5rem;
+    max-height: 480px;
+  }
+}
+
+@media (max-width: 768px) {
+  .story-editor-shell {
+    padding: 1.25rem 1.25rem 3rem;
+  }
+
+  .entity-editor {
+    width: calc(100% - 2rem);
+    right: 1rem;
+    bottom: 1rem;
+  }
+}

--- a/public/css/authorBuilder.css
+++ b/public/css/authorBuilder.css
@@ -469,6 +469,11 @@ map-node.color-rose {
   z-index: 30;
 }
 
+
+.hidden {
+  display: none !important;
+}
+
 .entity-editor.hidden {
   display: none;
 }

--- a/public/css/authorBuilder.css
+++ b/public/css/authorBuilder.css
@@ -89,6 +89,12 @@ body {
   letter-spacing: 0.02em;
 }
 
+.field .field-hint {
+  font-size: 0.75rem;
+  color: #7f8ea3;
+  font-weight: 400;
+}
+
 .field input,
 .field select,
 .field textarea {
@@ -114,6 +120,12 @@ body {
 .field.field--multiline textarea {
   min-height: 140px;
   background: rgba(24, 24, 24, 0.95);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
 }
 
 .field select option,

--- a/public/js/authorBuilder.js
+++ b/public/js/authorBuilder.js
@@ -1,0 +1,1000 @@
+(function () {
+  const COLOR_OPTIONS = ["twilight", "ember", "moss", "dusk", "rose", "slate"];
+  const ENDING_TYPES = ["true", "death", "secret", "other"];
+
+  const storyForm = document.getElementById("authorStoryForm");
+  const hiddenInputs = document.getElementById("builderDataInputs");
+  const builderDataEl = document.getElementById("builder-data");
+  const startNodeSelect = document.getElementById("story-start-node");
+  const mapViewport = document.getElementById("mapViewport");
+  const mapCanvas = document.getElementById("mapCanvas");
+  const linkLayer = document.getElementById("linkLayer");
+  const addNodeBtn = document.getElementById("add-node-btn");
+  const addEndingBtn = document.getElementById("add-ending-btn");
+  const centerSelectionBtn = document.getElementById("center-selection-btn");
+  const zoomOutBtn = document.getElementById("map-zoom-out-btn");
+  const zoomInBtn = document.getElementById("map-zoom-in-btn");
+  const entityEditor = document.getElementById("entityEditor");
+  const editorTitle = document.getElementById("entityEditorTitle");
+  const editorSubtitle = document.getElementById("entityEditorSubtitle");
+  const collapseBtn = document.getElementById("editorCollapseBtn");
+  const nodeDeleteBtn = document.getElementById("node-delete");
+  const endingDeleteBtn = document.getElementById("ending-delete");
+  const nodeForm = document.getElementById("node-form");
+  const endingForm = document.getElementById("ending-form");
+  const choiceList = document.getElementById("choice-list");
+  const choicesEmptyState = document.getElementById("choicesEmptyState");
+  const choiceAddForm = document.getElementById("choice-add-form");
+  const choiceAddLockToggle = choiceAddForm?.querySelector('[data-lock-toggle]');
+  const choiceAddCostInput = choiceAddForm?.querySelector('[data-lock-cost]');
+
+  if (!storyForm || !hiddenInputs || !builderDataEl) {
+    return;
+  }
+
+  const MIN_MAP_SCALE = 0.5;
+  const MAX_MAP_SCALE = 1.6;
+  const MAP_SCALE_STEP = 0.1;
+
+  let mapScale = 1;
+  let storyData = {};
+  let selected = null;
+  let drawFrame = null;
+  const elementIndex = new Map();
+
+  const parseInitial = () => {
+    try {
+      return JSON.parse(builderDataEl.textContent || "{}");
+    } catch (err) {
+      console.error("Failed to parse builder data", err);
+      return {};
+    }
+  };
+
+  const normalizeStory = (raw) => {
+    const story = Object.assign(
+      {
+        title: "",
+        description: "",
+        notes: "",
+        coverImage: "",
+        categories: [],
+        startNodeId: "",
+        nodes: [],
+        endings: [],
+      },
+      raw || {}
+    );
+    story.nodes = Array.isArray(story.nodes) ? story.nodes : [];
+    story.endings = Array.isArray(story.endings) ? story.endings : [];
+    story.categories = Array.isArray(story.categories) ? story.categories : [];
+    story.nodes = story.nodes.map((node) => ({
+      _id: node._id || "",
+      text: node.text || "",
+      image: node.image || "",
+      notes: node.notes || "",
+      color: COLOR_OPTIONS.includes(node.color) ? node.color : "twilight",
+      position: node.position || null,
+      choices: Array.isArray(node.choices)
+        ? node.choices.map((choice) => ({
+            _id: choice?._id || "",
+            label: choice?.label || "",
+            nextNodeId: choice?.nextNodeId || "",
+            locked: Boolean(choice?.locked),
+            unlockCost: Math.max(Number(choice?.unlockCost) || 0, 0),
+          }))
+        : [],
+    }));
+    story.endings = story.endings.map((ending) => ({
+      _id: ending._id || "",
+      label: ending.label || ending._id || "",
+      type: ENDING_TYPES.includes(ending.type) ? ending.type : "other",
+      text: ending.text || "",
+      notes: ending.notes || "",
+      image: ending.image || "",
+      position: ending.position || null,
+    }));
+    return story;
+  };
+
+  storyData = normalizeStory(parseInitial());
+
+  const ensurePositions = () => {
+    const spacingX = 240;
+    const spacingY = 200;
+    storyData.nodes.forEach((node, idx) => {
+      if (!node.position || typeof node.position.x !== "number" || typeof node.position.y !== "number") {
+        node.position = {
+          x: 160 + (idx % 5) * spacingX,
+          y: 160 + Math.floor(idx / 5) * spacingY,
+        };
+      }
+      if (!COLOR_OPTIONS.includes(node.color)) {
+        node.color = "twilight";
+      }
+    });
+    const nodeRows = Math.max(1, Math.ceil(storyData.nodes.length / 5));
+    storyData.endings.forEach((ending, idx) => {
+      if (!ending.position || typeof ending.position.x !== "number" || typeof ending.position.y !== "number") {
+        ending.position = {
+          x: 160 + (idx % 4) * spacingX,
+          y: 160 + (nodeRows + 1 + Math.floor(idx / 4)) * spacingY,
+        };
+      }
+      if (!ENDING_TYPES.includes(ending.type)) {
+        ending.type = "other";
+      }
+    });
+  };
+
+  ensurePositions();
+  const getViewportWidthInContent = (scale = mapScale) => {
+    const factor = scale > 0 ? scale : 1;
+    return mapViewport.clientWidth / factor;
+  };
+
+  const getViewportHeightInContent = (scale = mapScale) => {
+    const factor = scale > 0 ? scale : 1;
+    return mapViewport.clientHeight / factor;
+  };
+
+  const getViewportCenter = (scale = mapScale) => ({
+    x: mapViewport.scrollLeft + getViewportWidthInContent(scale) / 2,
+    y: mapViewport.scrollTop + getViewportHeightInContent(scale) / 2,
+  });
+
+  const applyMapScale = () => {
+    mapCanvas.style.transform = `scale(${mapScale})`;
+  };
+
+  const updateZoomButtons = () => {
+    if (zoomOutBtn) {
+      zoomOutBtn.disabled = mapScale <= MIN_MAP_SCALE + 0.001;
+    }
+    if (zoomInBtn) {
+      zoomInBtn.disabled = mapScale >= MAX_MAP_SCALE - 0.001;
+    }
+  };
+
+  applyMapScale();
+  updateZoomButtons();
+
+  const scheduleDrawLinks = () => {
+    if (drawFrame) return;
+    drawFrame = requestAnimationFrame(() => {
+      drawFrame = null;
+      drawLinks();
+    });
+  };
+
+  const updateStartNodeOptions = () => {
+    if (!startNodeSelect) return;
+    const selectedValue = storyData.startNodeId;
+    startNodeSelect.innerHTML = "";
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = "-- Select --";
+    startNodeSelect.appendChild(placeholder);
+    storyData.nodes.forEach((node) => {
+      const option = document.createElement("option");
+      option.value = node._id;
+      option.textContent = node._id || "(untitled)";
+      if (node._id === selectedValue) {
+        option.selected = true;
+      }
+      startNodeSelect.appendChild(option);
+    });
+  };
+
+  const populateDestinationSelect = (selectEl, selectedValue) => {
+    selectEl.innerHTML = "";
+    storyData.nodes.forEach((node) => {
+      const option = document.createElement("option");
+      option.value = node._id;
+      option.textContent = node._id || "(untitled)";
+      if (node._id === selectedValue) option.selected = true;
+      selectEl.appendChild(option);
+    });
+    storyData.endings.forEach((ending) => {
+      const option = document.createElement("option");
+      option.value = ending._id;
+      const typeLabel = ending.type ? ending.type.toUpperCase() : "ENDING";
+      option.textContent = `Ending: ${ending._id || "(untitled)"} (${typeLabel})`;
+      if (ending._id === selectedValue) option.selected = true;
+      selectEl.appendChild(option);
+    });
+  };
+
+  const drawLinks = () => {
+    const width = parseFloat(mapCanvas.style.width) || mapCanvas.scrollWidth || 2400;
+    const height = parseFloat(mapCanvas.style.height) || mapCanvas.scrollHeight || 1600;
+    linkLayer.setAttribute("width", width);
+    linkLayer.setAttribute("height", height);
+    linkLayer.setAttribute("viewBox", `0 0 ${width} ${height}`);
+    linkLayer.innerHTML = "";
+
+    const ns = "http://www.w3.org/2000/svg";
+    const defs = document.createElementNS(ns, "defs");
+    const createMarker = (id, color) => {
+      const marker = document.createElementNS(ns, "marker");
+      marker.setAttribute("id", id);
+      marker.setAttribute("markerWidth", "10");
+      marker.setAttribute("markerHeight", "10");
+      marker.setAttribute("refX", "8");
+      marker.setAttribute("refY", "5");
+      marker.setAttribute("orient", "auto");
+      marker.setAttribute("markerUnits", "strokeWidth");
+      const path = document.createElementNS(ns, "path");
+      path.setAttribute("d", "M0,0 L10,5 L0,10 z");
+      path.setAttribute("fill", color);
+      marker.appendChild(path);
+      return marker;
+    };
+    defs.appendChild(createMarker("link-arrow", "rgba(108, 92, 231, 0.75)"));
+    defs.appendChild(createMarker("link-arrow-ending", "rgba(255, 139, 92, 0.85)"));
+    linkLayer.appendChild(defs);
+
+    const frag = document.createDocumentFragment();
+    storyData.nodes.forEach((node) => {
+      const fromEntry = elementIndex.get(node._id);
+      if (!fromEntry) return;
+      (Array.isArray(node.choices) ? node.choices : []).forEach((choice) => {
+        const targetEntry = elementIndex.get(choice.nextNodeId);
+        if (!targetEntry) return;
+        const fromEl = fromEntry.element;
+        const toEl = targetEntry.element;
+        const fx = fromEl.offsetLeft + fromEl.offsetWidth / 2;
+        const fy = fromEl.offsetTop + fromEl.offsetHeight / 2;
+        const tx = toEl.offsetLeft + toEl.offsetWidth / 2;
+        const ty = toEl.offsetTop + toEl.offsetHeight / 2;
+        const midX = (fx + tx) / 2;
+        const midY = (fy + ty) / 2;
+        const path = document.createElementNS(ns, "path");
+        path.setAttribute("d", `M${fx},${fy} C${midX},${fy} ${midX},${ty} ${tx},${ty}`);
+        path.classList.add("link");
+        if (targetEntry.type === "ending") {
+          path.classList.add("to-ending");
+          path.setAttribute("marker-end", "url(#link-arrow-ending)");
+        } else {
+          path.setAttribute("marker-end", "url(#link-arrow)");
+        }
+        if (choice.locked) {
+          path.classList.add("locked");
+        }
+        frag.appendChild(path);
+        if (choice.locked) {
+          const lockIcon = document.createElementNS(ns, "text");
+          lockIcon.setAttribute("x", midX);
+          lockIcon.setAttribute("y", midY);
+          lockIcon.setAttribute("text-anchor", "middle");
+          lockIcon.setAttribute("dominant-baseline", "middle");
+          lockIcon.classList.add("link-lock-icon");
+          lockIcon.textContent = "🔒";
+          frag.appendChild(lockIcon);
+        }
+      });
+    });
+    linkLayer.appendChild(frag);
+  };
+
+  const highlightSelection = () => {
+    document
+      .querySelectorAll(".map-node.selected")
+      .forEach((el) => el.classList.remove("selected"));
+    if (!selected) return;
+    const entry = elementIndex.get(selected.id);
+    if (entry && entry.element) {
+      entry.element.classList.add("selected");
+    }
+  };
+
+  const updateEntityEditorVisibility = () => {
+    if (!selected) {
+      entityEditor.classList.add("hidden");
+      return;
+    }
+    entityEditor.classList.remove("hidden");
+  };
+  const renderChoices = (node) => {
+    if (!choiceList) return;
+    choiceList.innerHTML = "";
+    if (!node || !Array.isArray(node.choices) || node.choices.length === 0) {
+      choicesEmptyState.classList.remove("hidden");
+      return;
+    }
+    choicesEmptyState.classList.add("hidden");
+    node.choices.forEach((choice, index) => {
+      const item = document.createElement("div");
+      item.className = "choice-item";
+      if (choice.locked) {
+        item.classList.add("locked");
+      }
+
+      const fields = document.createElement("div");
+      fields.className = "choice-fields";
+
+      const idField = document.createElement("label");
+      idField.className = "choice-field";
+      const idSpan = document.createElement("span");
+      idSpan.textContent = "Choice ID";
+      const idInput = document.createElement("input");
+      idInput.type = "text";
+      idInput.value = choice._id || "";
+      idInput.placeholder = "optional";
+      idField.appendChild(idSpan);
+      idField.appendChild(idInput);
+
+      const labelField = document.createElement("label");
+      labelField.className = "choice-field choice-field--label";
+      const labelSpan = document.createElement("span");
+      labelSpan.textContent = "Label";
+      const labelInput = document.createElement("input");
+      labelInput.type = "text";
+      labelInput.value = choice.label || "";
+      labelField.appendChild(labelSpan);
+      labelField.appendChild(labelInput);
+
+      const selectField = document.createElement("label");
+      selectField.className = "choice-field";
+      const selectSpan = document.createElement("span");
+      selectSpan.textContent = "Next";
+      const select = document.createElement("select");
+      populateDestinationSelect(select, choice.nextNodeId);
+      selectField.appendChild(selectSpan);
+      selectField.appendChild(select);
+
+      const lockedField = document.createElement("label");
+      lockedField.className = "choice-field choice-field--toggle";
+      const lockedSpan = document.createElement("span");
+      lockedSpan.textContent = "Locked";
+      const lockedInput = document.createElement("input");
+      lockedInput.type = "checkbox";
+      lockedInput.checked = Boolean(choice.locked);
+      lockedField.appendChild(lockedSpan);
+      lockedField.appendChild(lockedInput);
+
+      const costField = document.createElement("label");
+      costField.className = "choice-field choice-field--cost";
+      const costSpan = document.createElement("span");
+      costSpan.textContent = "Unlock Cost";
+      const costInput = document.createElement("input");
+      costInput.type = "number";
+      costInput.min = "0";
+      costInput.step = "1";
+      costInput.value = Math.max(Number(choice.unlockCost) || 0, 0);
+      costField.appendChild(costSpan);
+      costField.appendChild(costInput);
+
+      fields.appendChild(idField);
+      fields.appendChild(labelField);
+      fields.appendChild(selectField);
+      fields.appendChild(lockedField);
+      fields.appendChild(costField);
+      item.appendChild(fields);
+
+      const actions = document.createElement("div");
+      actions.className = "choice-actions";
+      const removeBtn = document.createElement("button");
+      removeBtn.type = "button";
+      removeBtn.className = "btn small danger";
+      removeBtn.textContent = "Remove";
+      actions.appendChild(removeBtn);
+      item.appendChild(actions);
+
+      const syncLockState = () => {
+        const isLocked = lockedInput.checked;
+        item.classList.toggle("locked", isLocked);
+        costInput.disabled = !isLocked;
+      };
+      syncLockState();
+
+      idInput.addEventListener("input", () => {
+        choice._id = idInput.value.trim();
+      });
+      labelInput.addEventListener("input", () => {
+        choice.label = labelInput.value;
+      });
+      select.addEventListener("change", () => {
+        choice.nextNodeId = select.value;
+        scheduleDrawLinks();
+      });
+      lockedInput.addEventListener("change", () => {
+        choice.locked = lockedInput.checked;
+        if (!choice.locked) {
+          choice.unlockCost = 0;
+          costInput.value = "0";
+        }
+        syncLockState();
+        scheduleDrawLinks();
+      });
+      costInput.addEventListener("input", () => {
+        const value = Math.max(Number(costInput.value) || 0, 0);
+        choice.unlockCost = value;
+        costInput.value = String(value);
+      });
+
+      removeBtn.addEventListener("click", () => {
+        node.choices.splice(index, 1);
+        renderChoices(node);
+        scheduleDrawLinks();
+      });
+
+      choiceList.appendChild(item);
+    });
+  };
+
+  const fillNodeForm = (node) => {
+    if (!node) return;
+    nodeForm.dataset.originalId = node._id;
+    nodeForm.elements._id.value = node._id || "";
+    nodeForm.elements.color.value = COLOR_OPTIONS.includes(node.color) ? node.color : "twilight";
+    nodeForm.elements.image.value = node.image || "";
+    nodeForm.elements.text.value = node.text || "";
+    if (nodeForm.elements.notes) {
+      nodeForm.elements.notes.value = node.notes || "";
+    }
+  };
+
+  const fillEndingForm = (ending) => {
+    if (!ending) return;
+    endingForm.dataset.originalId = ending._id;
+    endingForm.elements._id.value = ending._id || "";
+    endingForm.elements.label.value = ending.label || "";
+    endingForm.elements.type.value = ENDING_TYPES.includes(ending.type) ? ending.type : "other";
+    endingForm.elements.image.value = ending.image || "";
+    endingForm.elements.text.value = ending.text || "";
+    if (endingForm.elements.notes) {
+      endingForm.elements.notes.value = ending.notes || "";
+    }
+  };
+
+  const refreshInspector = () => {
+    if (!selected) {
+      nodeForm.classList.add("hidden");
+      endingForm.classList.add("hidden");
+      choiceAddForm.classList.add("hidden");
+      document.querySelectorAll('[data-editor="node"]').forEach((el) => el.classList.add("hidden"));
+      nodeDeleteBtn.classList.add("hidden");
+      endingDeleteBtn.classList.add("hidden");
+      editorSubtitle.textContent = "";
+      return;
+    }
+    if (selected.type === "node") {
+      const node = storyData.nodes.find((n) => n._id === selected.id);
+      if (!node) return;
+      editorTitle.textContent = "Passage";
+      editorSubtitle.textContent = node._id || "Unnamed passage";
+      nodeDeleteBtn.classList.remove("hidden");
+      endingDeleteBtn.classList.add("hidden");
+      nodeForm.classList.remove("hidden");
+      endingForm.classList.add("hidden");
+      document.querySelectorAll('[data-editor="node"]').forEach((el) => el.classList.remove("hidden"));
+      choiceAddForm.dataset.nodeId = node._id;
+      populateDestinationSelect(choiceAddForm.elements.nextNodeId, "");
+      fillNodeForm(node);
+      renderChoices(node);
+    } else if (selected.type === "ending") {
+      const ending = storyData.endings.find((e) => e._id === selected.id);
+      if (!ending) return;
+      editorTitle.textContent = "Ending";
+      editorSubtitle.textContent = ending._id || "Unnamed ending";
+      nodeDeleteBtn.classList.add("hidden");
+      endingDeleteBtn.classList.remove("hidden");
+      document.querySelectorAll('[data-editor="node"]').forEach((el) => el.classList.add("hidden"));
+      nodeForm.classList.add("hidden");
+      endingForm.classList.remove("hidden");
+      fillEndingForm(ending);
+    }
+  };
+  const selectEntity = (type, id, { focusInspector = true } = {}) => {
+    if (!type || !id) {
+      selected = null;
+      highlightSelection();
+      refreshInspector();
+      updateEntityEditorVisibility();
+      return;
+    }
+    selected = { type, id };
+    highlightSelection();
+    refreshInspector();
+    updateEntityEditorVisibility();
+    if (focusInspector) {
+      entityEditor.classList.remove("collapsed");
+      collapseBtn.textContent = "Collapse";
+      collapseBtn.setAttribute("aria-expanded", "true");
+    }
+  };
+
+  const renderMap = () => {
+    elementIndex.clear();
+    const existingLinks = linkLayer;
+    mapCanvas.innerHTML = "";
+    mapCanvas.appendChild(existingLinks);
+
+    const entities = [...storyData.nodes, ...storyData.endings];
+    let maxX = 600;
+    let maxY = 400;
+    entities.forEach((entity) => {
+      if (!entity.position) return;
+      maxX = Math.max(maxX, entity.position.x + 320);
+      maxY = Math.max(maxY, entity.position.y + 260);
+    });
+    const viewportWidth = mapViewport.clientWidth || 0;
+    const viewportHeight = mapViewport.clientHeight || 0;
+    const width = Math.max(960, viewportWidth, maxX + 160);
+    const height = Math.max(720, viewportHeight, maxY + 160);
+    mapCanvas.style.width = `${width}px`;
+    mapCanvas.style.height = `${height}px`;
+    existingLinks.setAttribute("width", width);
+    existingLinks.setAttribute("height", height);
+    existingLinks.setAttribute("viewBox", `0 0 ${width} ${height}`);
+    existingLinks.style.width = `${width}px`;
+    existingLinks.style.height = `${height}px`;
+
+    const createElement = (entity, type) => {
+      const el = document.createElement("div");
+      el.className = `map-node ${type} draggable`;
+      if (type === "node") {
+        el.classList.add(`color-${entity.color || "twilight"}`);
+        if (storyData.startNodeId === entity._id) {
+          el.classList.add("start-node");
+        }
+      }
+      el.dataset.id = entity._id;
+      el.dataset.entityType = type;
+      const x = entity.position?.x ?? 0;
+      const y = entity.position?.y ?? 0;
+      el.dataset.x = x;
+      el.dataset.y = y;
+      el.style.left = `${x}px`;
+      el.style.top = `${y}px`;
+
+      const header = document.createElement("div");
+      header.className = "node-title";
+      const idSpan = document.createElement("span");
+      idSpan.className = "node-id";
+      idSpan.textContent = entity._id || "(untitled)";
+      header.appendChild(idSpan);
+      if (entity.image) {
+        const imgFlag = document.createElement("span");
+        imgFlag.className = "image-flag";
+        imgFlag.textContent = "🖼";
+        header.appendChild(imgFlag);
+      }
+      el.appendChild(header);
+
+      const snippet = document.createElement("p");
+      snippet.className = "node-snippet";
+      const textSource = entity.text || entity.notes || "";
+      snippet.textContent = textSource.slice(0, 140) + (textSource.length > 140 ? "…" : "");
+      el.appendChild(snippet);
+
+      const meta = document.createElement("div");
+      meta.className = "node-meta";
+      if (type === "node") {
+        const choiceCount = Array.isArray(entity.choices) ? entity.choices.length : 0;
+        meta.textContent = `${choiceCount} choice${choiceCount === 1 ? "" : "s"}`;
+      } else {
+        meta.textContent = (entity.type || "other").toUpperCase();
+      }
+      el.appendChild(meta);
+
+      el.addEventListener("click", (event) => {
+        event.stopPropagation();
+        selectEntity(type, entity._id);
+      });
+
+      elementIndex.set(entity._id, { element: el, type });
+      mapCanvas.appendChild(el);
+    };
+
+    storyData.nodes.forEach((node) => {
+      createElement(node, "node");
+    });
+    storyData.endings.forEach((ending) => {
+      createElement(ending, "ending");
+    });
+
+    highlightSelection();
+    drawLinks();
+  };
+
+  interact(".map-node.draggable").draggable({
+    listeners: {
+      move(event) {
+        const target = event.target;
+        const deltaX = event.dx / (mapScale || 1);
+        const deltaY = event.dy / (mapScale || 1);
+        const x = (parseFloat(target.dataset.x) || 0) + deltaX;
+        const y = (parseFloat(target.dataset.y) || 0) + deltaY;
+        target.dataset.x = x;
+        target.dataset.y = y;
+        target.style.left = `${x}px`;
+        target.style.top = `${y}px`;
+        scheduleDrawLinks();
+      },
+      end(event) {
+        const target = event.target;
+        const id = target.dataset.id;
+        const type = target.dataset.entityType || "node";
+        const x = parseFloat(target.dataset.x) || 0;
+        const y = parseFloat(target.dataset.y) || 0;
+        if (!id) return;
+        if (type === "node") {
+          const node = storyData.nodes.find((n) => n._id === id);
+          if (node) {
+            node.position = { x, y };
+          }
+        } else {
+          const ending = storyData.endings.find((e) => e._id === id);
+          if (ending) {
+            ending.position = { x, y };
+          }
+        }
+      },
+    },
+    inertia: false,
+  });
+
+  renderMap();
+  updateStartNodeOptions();
+  refreshInspector();
+  updateEntityEditorVisibility();
+  mapViewport.addEventListener("click", () => {
+    selectEntity(null, null);
+  });
+
+  collapseBtn.addEventListener("click", () => {
+    const isCollapsed = entityEditor.classList.toggle("collapsed");
+    collapseBtn.textContent = isCollapsed ? "Expand" : "Collapse";
+    collapseBtn.setAttribute("aria-expanded", String(!isCollapsed));
+  });
+
+  const changeMapScale = (delta) => {
+    const proposed = Math.round((mapScale + delta) * 100) / 100;
+    const nextScale = Math.min(MAX_MAP_SCALE, Math.max(MIN_MAP_SCALE, proposed));
+    if (nextScale === mapScale) return;
+    const previousScale = mapScale;
+    const previousCenter = getViewportCenter(previousScale);
+    mapScale = nextScale;
+    applyMapScale();
+    updateZoomButtons();
+    const nextWidth = getViewportWidthInContent();
+    const nextHeight = getViewportHeightInContent();
+    mapViewport.scrollTo({
+      left: Math.max(previousCenter.x - nextWidth / 2, 0),
+      top: Math.max(previousCenter.y - nextHeight / 2, 0),
+    });
+    scheduleDrawLinks();
+  };
+
+  if (zoomOutBtn) {
+    zoomOutBtn.addEventListener("click", () => {
+      changeMapScale(-MAP_SCALE_STEP);
+    });
+  }
+  if (zoomInBtn) {
+    zoomInBtn.addEventListener("click", () => {
+      changeMapScale(MAP_SCALE_STEP);
+    });
+  }
+
+  centerSelectionBtn?.addEventListener("click", () => {
+    if (!selected) return;
+    const entry = elementIndex.get(selected.id);
+    if (!entry) return;
+    const el = entry.element;
+    const viewportWidth = getViewportWidthInContent();
+    const viewportHeight = getViewportHeightInContent();
+    const x = el.offsetLeft + el.offsetWidth / 2 - viewportWidth / 2;
+    const y = el.offsetTop + el.offsetHeight / 2 - viewportHeight / 2;
+    mapViewport.scrollTo({ left: Math.max(x, 0), top: Math.max(y, 0), behavior: "smooth" });
+  });
+
+  const generateUniqueId = (prefix) => {
+    let counter = 1;
+    let candidate = `${prefix}-${counter}`;
+    const exists = (id) =>
+      storyData.nodes.some((n) => n._id === id) || storyData.endings.some((e) => e._id === id);
+    while (exists(candidate)) {
+      counter += 1;
+      candidate = `${prefix}-${counter}`;
+    }
+    return candidate;
+  };
+
+  addNodeBtn?.addEventListener("click", () => {
+    const center = getViewportCenter();
+    const newId = generateUniqueId("passage");
+    const node = {
+      _id: newId,
+      text: "",
+      notes: "",
+      image: "",
+      color: "twilight",
+      position: { x: center.x - 110, y: center.y - 80 },
+      choices: [],
+    };
+    storyData.nodes.push(node);
+    if (!storyData.startNodeId) {
+      storyData.startNodeId = node._id;
+    }
+    renderMap();
+    updateStartNodeOptions();
+    selectEntity("node", node._id);
+  });
+
+  addEndingBtn?.addEventListener("click", () => {
+    const center = getViewportCenter();
+    const newId = generateUniqueId("ending");
+    const ending = {
+      _id: newId,
+      label: newId,
+      type: "other",
+      text: "",
+      notes: "",
+      image: "",
+      position: { x: center.x - 110, y: center.y - 80 },
+    };
+    storyData.endings.push(ending);
+    renderMap();
+    updateStartNodeOptions();
+    selectEntity("ending", ending._id);
+  });
+
+  nodeForm.addEventListener("input", () => {
+    if (!selected || selected.type !== "node") return;
+    const node = storyData.nodes.find((n) => n._id === nodeForm.dataset.originalId);
+    if (!node) return;
+    const previousId = node._id;
+    node._id = nodeForm.elements._id.value.trim();
+    node.color = nodeForm.elements.color.value;
+    node.image = nodeForm.elements.image.value.trim();
+    node.text = nodeForm.elements.text.value;
+    if (nodeForm.elements.notes) {
+      node.notes = nodeForm.elements.notes.value;
+    }
+    if (previousId !== node._id) {
+      if (storyData.startNodeId === previousId) {
+        storyData.startNodeId = node._id;
+      }
+      storyData.nodes.forEach((n) => {
+        n.choices.forEach((choice) => {
+          if (choice.nextNodeId === previousId) {
+            choice.nextNodeId = node._id;
+          }
+        });
+      });
+      if (selected && selected.id === previousId) {
+        selected.id = node._id;
+      }
+      nodeForm.dataset.originalId = node._id;
+    }
+    updateStartNodeOptions();
+    populateDestinationSelect(choiceAddForm.elements.nextNodeId, "");
+    renderMap();
+    selectEntity("node", node._id, { focusInspector: false });
+  });
+
+  endingForm.addEventListener("input", () => {
+    if (!selected || selected.type !== "ending") return;
+    const ending = storyData.endings.find((e) => e._id === endingForm.dataset.originalId);
+    if (!ending) return;
+    const previousId = ending._id;
+    ending._id = endingForm.elements._id.value.trim();
+    ending.label = endingForm.elements.label.value.trim() || ending._id;
+    ending.type = endingForm.elements.type.value;
+    ending.image = endingForm.elements.image.value.trim();
+    ending.text = endingForm.elements.text.value;
+    if (endingForm.elements.notes) {
+      ending.notes = endingForm.elements.notes.value;
+    }
+    if (previousId !== ending._id) {
+      storyData.nodes.forEach((node) => {
+        node.choices.forEach((choice) => {
+          if (choice.nextNodeId === previousId) {
+            choice.nextNodeId = ending._id;
+          }
+        });
+      });
+      if (selected && selected.id === previousId) {
+        selected.id = ending._id;
+      }
+      endingForm.dataset.originalId = ending._id;
+    }
+    populateDestinationSelect(choiceAddForm.elements.nextNodeId, "");
+    renderMap();
+    selectEntity("ending", ending._id, { focusInspector: false });
+  });
+
+  choiceAddForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (!selected || selected.type !== "node") return;
+    const node = storyData.nodes.find((n) => n._id === selected.id);
+    if (!node) return;
+    const choice = {
+      _id: (choiceAddForm.elements._id.value || "").trim(),
+      label: choiceAddForm.elements.label.value.trim(),
+      nextNodeId: choiceAddForm.elements.nextNodeId.value,
+      locked: Boolean(choiceAddLockToggle?.checked),
+      unlockCost: Boolean(choiceAddLockToggle?.checked)
+        ? Math.max(Number(choiceAddCostInput?.value) || 0, 0)
+        : 0,
+    };
+    node.choices.push(choice);
+    choiceAddForm.reset();
+    if (choiceAddCostInput) {
+      choiceAddCostInput.value = "0";
+    }
+    if (choiceAddLockToggle) {
+      choiceAddLockToggle.checked = false;
+    }
+    renderChoices(node);
+    scheduleDrawLinks();
+  });
+
+  const syncAddLockState = () => {
+    if (!choiceAddCostInput || !choiceAddLockToggle) return;
+    const isLocked = choiceAddLockToggle.checked;
+    choiceAddCostInput.disabled = !isLocked;
+    if (!isLocked) {
+      choiceAddCostInput.value = "0";
+    }
+  };
+  if (choiceAddLockToggle) {
+    choiceAddLockToggle.addEventListener("change", syncAddLockState);
+    syncAddLockState();
+  }
+
+  nodeDeleteBtn.addEventListener("click", () => {
+    if (!selected || selected.type !== "node") return;
+    const idx = storyData.nodes.findIndex((n) => n._id === selected.id);
+    if (idx === -1) return;
+    if (!confirm("Delete this passage?")) return;
+    const removedId = storyData.nodes[idx]._id;
+    storyData.nodes.splice(idx, 1);
+    if (storyData.startNodeId === removedId) {
+      storyData.startNodeId = storyData.nodes[0]?._id || "";
+    }
+    storyData.nodes.forEach((node) => {
+      node.choices = node.choices.filter((choice) => choice.nextNodeId !== removedId);
+    });
+    renderMap();
+    updateStartNodeOptions();
+    selectEntity(null, null);
+  });
+
+  endingDeleteBtn.addEventListener("click", () => {
+    if (!selected || selected.type !== "ending") return;
+    const idx = storyData.endings.findIndex((e) => e._id === selected.id);
+    if (idx === -1) return;
+    if (!confirm("Delete this ending?")) return;
+    const removedId = storyData.endings[idx]._id;
+    storyData.endings.splice(idx, 1);
+    storyData.nodes.forEach((node) => {
+      node.choices.forEach((choice) => {
+        if (choice.nextNodeId === removedId) {
+          choice.nextNodeId = "";
+        }
+      });
+    });
+    renderMap();
+    updateStartNodeOptions();
+    selectEntity(null, null);
+  });
+
+  startNodeSelect?.addEventListener("change", () => {
+    storyData.startNodeId = startNodeSelect.value;
+    renderMap();
+  });
+  const validateStory = () => {
+    const errors = [];
+    const nodeIds = new Set();
+    storyData.nodes.forEach((node, index) => {
+      if (!node._id) {
+        errors.push(`Passage #${index + 1} needs an id.`);
+      } else if (nodeIds.has(node._id)) {
+        errors.push(`Duplicate passage id "${node._id}".`);
+      } else {
+        nodeIds.add(node._id);
+      }
+      node.choices.forEach((choice, cIndex) => {
+        if (!choice.label) {
+          errors.push(`Choice #${cIndex + 1} in passage "${node._id}" needs a label.`);
+        }
+        if (!choice.nextNodeId) {
+          errors.push(`Choice #${cIndex + 1} in passage "${node._id}" needs a destination.`);
+        }
+      });
+    });
+    const endingIds = new Set();
+    storyData.endings.forEach((ending, index) => {
+      if (!ending._id) {
+        errors.push(`Ending #${index + 1} needs an id.`);
+      } else if (endingIds.has(ending._id)) {
+        errors.push(`Duplicate ending id "${ending._id}".`);
+      } else {
+        endingIds.add(ending._id);
+      }
+    });
+    if (!storyData.nodes.length) {
+      errors.push("Add at least one passage.");
+    }
+    if (!storyData.endings.length) {
+      errors.push("Add at least one ending.");
+    }
+    if (!storyData.startNodeId) {
+      errors.push("Select a starting passage.");
+    }
+    return errors;
+  };
+
+  const createHiddenInput = (name, value) => {
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    return input;
+  };
+
+  const persistStoryData = () => {
+    hiddenInputs.innerHTML = "";
+    storyData.nodes.forEach((node, index) => {
+      hiddenInputs.appendChild(createHiddenInput(`nodes[${index}][_id]`, node._id));
+      hiddenInputs.appendChild(createHiddenInput(`nodes[${index}][text]`, node.text));
+      hiddenInputs.appendChild(createHiddenInput(`nodes[${index}][image]`, node.image));
+      hiddenInputs.appendChild(createHiddenInput(`nodes[${index}][notes]`, node.notes || ""));
+      hiddenInputs.appendChild(createHiddenInput(`nodes[${index}][color]`, node.color));
+      hiddenInputs.appendChild(createHiddenInput(`nodes[${index}][position][x]`, node.position?.x ?? 0));
+      hiddenInputs.appendChild(createHiddenInput(`nodes[${index}][position][y]`, node.position?.y ?? 0));
+      node.choices.forEach((choice, cIndex) => {
+        hiddenInputs.appendChild(
+          createHiddenInput(`nodes[${index}][choices][${cIndex}][_id]`, choice._id || "")
+        );
+        hiddenInputs.appendChild(
+          createHiddenInput(`nodes[${index}][choices][${cIndex}][label]`, choice.label || "")
+        );
+        hiddenInputs.appendChild(
+          createHiddenInput(
+            `nodes[${index}][choices][${cIndex}][nextNodeId]`,
+            choice.nextNodeId || ""
+          )
+        );
+        hiddenInputs.appendChild(
+          createHiddenInput(
+            `nodes[${index}][choices][${cIndex}][locked]`,
+            choice.locked ? "true" : "false"
+          )
+        );
+        hiddenInputs.appendChild(
+          createHiddenInput(
+            `nodes[${index}][choices][${cIndex}][unlockCost]`,
+            String(Math.max(Number(choice.unlockCost) || 0, 0))
+          )
+        );
+      });
+    });
+
+    storyData.endings.forEach((ending, index) => {
+      hiddenInputs.appendChild(createHiddenInput(`endings[${index}][_id]`, ending._id));
+      hiddenInputs.appendChild(createHiddenInput(`endings[${index}][label]`, ending.label || ""));
+      hiddenInputs.appendChild(createHiddenInput(`endings[${index}][type]`, ending.type));
+      hiddenInputs.appendChild(createHiddenInput(`endings[${index}][image]`, ending.image || ""));
+      hiddenInputs.appendChild(createHiddenInput(`endings[${index}][text]`, ending.text || ""));
+      hiddenInputs.appendChild(createHiddenInput(`endings[${index}][notes]`, ending.notes || ""));
+      hiddenInputs.appendChild(createHiddenInput(`endings[${index}][position][x]`, ending.position?.x ?? 0));
+      hiddenInputs.appendChild(createHiddenInput(`endings[${index}][position][y]`, ending.position?.y ?? 0));
+    });
+  };
+
+  storyForm.addEventListener("submit", (event) => {
+    const errors = validateStory();
+    if (errors.length) {
+      event.preventDefault();
+      alert(errors.join("\n"));
+      return;
+    }
+    storyData.startNodeId = startNodeSelect?.value || storyData.startNodeId;
+    persistStoryData();
+  });
+})();

--- a/public/styles.css
+++ b/public/styles.css
@@ -242,8 +242,16 @@ nav a:hover {
   height: 1.1rem;
 }
 
-.choice-cost .icon svg {
+.icon-gem {
   color: #fcd34d;
+}
+
+.icon-author-gem {
+  color: #c084fc;
+}
+
+.choice-cost .icon svg {
+  color: inherit;
 }
 
 .choice-cost {
@@ -307,7 +315,7 @@ nav a:hover {
 .currency-readout .icon svg {
   width: 1.35rem;
   height: 1.35rem;
-  color: #fcd34d;
+  color: inherit;
 }
 
 .currency-readout__content {
@@ -510,6 +518,12 @@ nav a:hover {
   gap: 0.55rem;
 }
 
+.story-card__author {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.85);
+}
+
 .story-card__actions {
   margin-top: 0.85rem;
   display: flex;
@@ -529,6 +543,93 @@ nav a:hover {
   align-self: flex-start;
   padding: 0.5rem 1rem;
   font-size: 0.9rem;
+}
+
+.library-nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1rem 0 0.5rem;
+}
+
+.library-nav-links .cta-button {
+  padding: 0.55rem 1.25rem;
+  font-size: 0.95rem;
+}
+
+.story-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.12);
+  color: #e2e8f0;
+}
+
+.story-status-label {
+  font-weight: 600;
+}
+
+.story-status-public {
+  background: rgba(34, 197, 94, 0.15);
+  border-color: rgba(34, 197, 94, 0.32);
+  color: #bbf7d0;
+}
+
+.story-status-pending,
+.story-status-coming_soon {
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(59, 130, 246, 0.32);
+  color: #bfdbfe;
+}
+
+.story-status-under_review {
+  background: rgba(244, 114, 182, 0.2);
+  border-color: rgba(244, 114, 182, 0.35);
+  color: #fbcfe8;
+}
+
+.story-status-private {
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(148, 163, 184, 0.32);
+  color: #e2e8f0;
+}
+
+.story-status-banner {
+  margin: 1rem 0;
+  padding: 0.85rem 1.1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.6);
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.story-status-banner.story-status-pending,
+.story-status-banner.story-status-coming_soon {
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.28);
+}
+
+.story-status-banner.story-status-under_review {
+  background: rgba(244, 114, 182, 0.12);
+  border-color: rgba(244, 114, 182, 0.28);
+}
+
+.story-status-message {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.85rem 1.1rem;
+  background: rgba(15, 23, 42, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .coming-soon {

--- a/public/styles.css
+++ b/public/styles.css
@@ -34,6 +34,41 @@ header h1 {
   color: var(--accent-red);
 }
 
+.menu-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--text-light);
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.menu-toggle__bar {
+  display: block;
+  width: 1.5rem;
+  height: 2px;
+  background: currentColor;
+  margin: 0.25rem 0;
+  transition: background 0.3s;
+}
+
+.menu-toggle:focus-visible {
+  outline: 2px solid var(--accent-purple);
+  outline-offset: 2px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 nav a {
   margin-left: 1.5rem;
   text-decoration: none;
@@ -72,6 +107,55 @@ nav a:hover {
 
 .logout-form {
   display: inline; /* keeps button inline like links */
+}
+
+@media (max-width: 800px) {
+  header {
+    flex-wrap: wrap;
+    row-gap: 0.75rem;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin-left: auto;
+  }
+
+  .top-nav {
+    display: none;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+    width: 100%;
+    padding-top: 0.5rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .top-nav[data-visible="true"] {
+    display: flex;
+  }
+
+  nav a {
+    margin-left: 0;
+  }
+
+  .top-nav a,
+  .top-nav button {
+    width: 100%;
+    text-align: left;
+    padding: 0.25rem 0;
+  }
+
+  .logout-form {
+    width: 100%;
+  }
+
+  .logout-form button {
+    width: 100%;
+    text-align: left;
+  }
 }
 
 .hero {

--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -58,6 +58,7 @@ router.post(
   controller.markUserStoryUnderReview
 );
 router.post("/user-stories/:id/remove", controller.removeUserStory);
+router.post("/user-stories/:id/note", controller.updateUserStoryNote);
 
 /* ---------------- Stories ---------------- */
 router.get("/stories", controller.storiesList);

--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -75,6 +75,7 @@ router.get("/users", controller.usersList);
 router.get("/users/add", controller.userAddForm);
 router.post("/users/add", controller.userAddPost);
 router.get("/users/:id", controller.userDetail);
+router.get("/users/:id/library", controller.userAuthorLibrary);
 router.post("/users/:id", controller.userUpdate);
 router.post("/users/:id/reset-password", controller.userResetPassword);
 router.post("/users/:id/delete", controller.userDelete);

--- a/routes/admin.routes.js
+++ b/routes/admin.routes.js
@@ -51,6 +51,13 @@ router.use(requireAdmin);
 
 /* ---------------- Dashboard ---------------- */
 router.get("/", controller.dashboard);
+router.post("/user-stories/:id/approve", controller.approveUserStory);
+router.post("/user-stories/:id/reject", controller.rejectUserStory);
+router.post(
+  "/user-stories/:id/under-review",
+  controller.markUserStoryUnderReview
+);
+router.post("/user-stories/:id/remove", controller.removeUserStory);
 
 /* ---------------- Stories ---------------- */
 router.get("/stories", controller.storiesList);

--- a/routes/user.routes.js
+++ b/routes/user.routes.js
@@ -13,6 +13,7 @@ const {
   authorStoryForm,
   authorStoryCreate,
   authorStoryUpdate,
+  authorStoryAutosave,
   authorStorySubmit,
   authorStorySetPrivate,
   authorStoryDelete,
@@ -75,6 +76,7 @@ router.post("/authors/stories/new", authorStoryCreateDraft);
 router.get("/authors/stories/:id/edit", authorStoryForm);
 router.post("/authors/stories", authorStoryCreate);
 router.post("/authors/stories/:id", authorStoryUpdate);
+router.post("/authors/stories/:id/autosave", authorStoryAutosave);
 router.post("/authors/stories/:id/submit", authorStorySubmit);
 router.post("/authors/stories/:id/private", authorStorySetPrivate);
 router.post("/authors/stories/:id/delete", authorStoryDelete);

--- a/routes/user.routes.js
+++ b/routes/user.routes.js
@@ -1,6 +1,16 @@
 const express = require("express");
 const { requireAuth } = require("../middleware/auth");
-const { library, stats } = require("../controllers/user.controller");
+const {
+  library,
+  stats,
+  userStoriesLibrary,
+  authorDashboard,
+  authorStoryForm,
+  authorStoryCreate,
+  authorStoryUpdate,
+  authorStorySubmit,
+  authorStorySetPrivate,
+} = require("../controllers/user.controller");
 const {
   storyLanding,
   playNode,
@@ -12,7 +22,15 @@ const router = express.Router();
 
 router.use(requireAuth); // everything requires login
 router.get("/library", library);
+router.get("/library/user-stories", userStoriesLibrary);
 router.get("/stats", stats);
+router.get("/authors", authorDashboard);
+router.get("/authors/stories/new", authorStoryForm);
+router.get("/authors/stories/:id/edit", authorStoryForm);
+router.post("/authors/stories", authorStoryCreate);
+router.post("/authors/stories/:id", authorStoryUpdate);
+router.post("/authors/stories/:id/submit", authorStorySubmit);
+router.post("/authors/stories/:id/private", authorStorySetPrivate);
 router.get("/story/:id", storyLanding);
 router.get("/play/:id/:nodeId", playNode);
 router.get("/play/:id/ending/:endingId", playEnding);

--- a/routes/user.routes.js
+++ b/routes/user.routes.js
@@ -1,15 +1,23 @@
+require("dotenv").config();
 const express = require("express");
+const multer = require("multer");
+const { v2: cloudinary } = require("cloudinary");
+const { CloudinaryStorage } = require("multer-storage-cloudinary");
 const { requireAuth } = require("../middleware/auth");
 const {
   library,
   stats,
   userStoriesLibrary,
   authorDashboard,
+  authorStoryCreateDraft,
   authorStoryForm,
   authorStoryCreate,
   authorStoryUpdate,
   authorStorySubmit,
   authorStorySetPrivate,
+  authorStoryImages,
+  authorStoryImageUpload,
+  authorStoryImageDelete,
 } = require("../controllers/user.controller");
 const {
   storyLanding,
@@ -25,12 +33,59 @@ router.get("/library", library);
 router.get("/library/user-stories", userStoriesLibrary);
 router.get("/stats", stats);
 router.get("/authors", authorDashboard);
-router.get("/authors/stories/new", authorStoryForm);
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
+const authorImageStorage = new CloudinaryStorage({
+  cloudinary,
+  params: async (req, file) => {
+    const storyId = req.params.id;
+    const authorId = req.user?._id ? String(req.user._id) : "unknown";
+    const baseName = (file.originalname || "image")
+      .replace(/\.[^.]+$/, "")
+      .replace(/[^a-z0-9-_]+/gi, "-");
+    return {
+      folder: `authors/${authorId}/${storyId || "library"}`,
+      public_id: `${Date.now()}-${baseName}`,
+      resource_type: "image",
+      allowed_formats: ["jpg", "jpeg", "png", "gif", "webp"],
+      transformation: [{ quality: "auto", fetch_format: "auto" }],
+      context: {
+        story_id: String(storyId || ""),
+        author_id: authorId,
+      },
+    };
+  },
+});
+
+const authorImageUpload = multer({
+  storage: authorImageStorage,
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    const ok = /image\/(png|jpe?g|gif|webp)$/i.test(file.mimetype);
+    cb(ok ? null : new Error("Only image files are allowed"), ok);
+  },
+});
+
+router.post("/authors/stories/new", authorStoryCreateDraft);
 router.get("/authors/stories/:id/edit", authorStoryForm);
 router.post("/authors/stories", authorStoryCreate);
 router.post("/authors/stories/:id", authorStoryUpdate);
 router.post("/authors/stories/:id/submit", authorStorySubmit);
 router.post("/authors/stories/:id/private", authorStorySetPrivate);
+router.get("/authors/stories/:id/images", authorStoryImages);
+router.post(
+  "/authors/stories/:id/images/upload",
+  authorImageUpload.single("image"),
+  authorStoryImageUpload
+);
+router.post(
+  "/authors/stories/:id/images/delete",
+  authorStoryImageDelete
+);
 router.get("/story/:id", storyLanding);
 router.get("/play/:id/:nodeId", playNode);
 router.get("/play/:id/ending/:endingId", playEnding);

--- a/routes/user.routes.js
+++ b/routes/user.routes.js
@@ -15,6 +15,7 @@ const {
   authorStoryUpdate,
   authorStorySubmit,
   authorStorySetPrivate,
+  authorStoryDelete,
   authorStoryImages,
   authorStoryImageUpload,
   authorStoryImageDelete,
@@ -76,6 +77,7 @@ router.post("/authors/stories", authorStoryCreate);
 router.post("/authors/stories/:id", authorStoryUpdate);
 router.post("/authors/stories/:id/submit", authorStorySubmit);
 router.post("/authors/stories/:id/private", authorStorySetPrivate);
+router.post("/authors/stories/:id/delete", authorStoryDelete);
 router.get("/authors/stories/:id/images", authorStoryImages);
 router.post(
   "/authors/stories/:id/images/upload",

--- a/utils/authorRewards.js
+++ b/utils/authorRewards.js
@@ -1,0 +1,186 @@
+const Story = require("../models/story.model");
+const User = require("../models/user.model");
+
+const LEVEL_ORDER = ["none", "bronze", "silver", "gold", "platinum"];
+
+const TROPHY_CONFIG = {
+  storyBuilder: {
+    thresholds: { bronze: 1, silver: 3, gold: 5, platinum: 10 },
+    rewards: { bronze: 25, silver: 50, gold: 100, platinum: 200 },
+    currencyLabel: "author gems",
+    message: (level) => `Story Builder trophy reached ${titleCase(level)}!`,
+  },
+  publishedAuthor: {
+    thresholds: { bronze: 1, silver: 3, gold: 5, platinum: 10 },
+    rewards: { bronze: 40, silver: 80, gold: 160, platinum: 300 },
+    currencyLabel: "author gems",
+    message: (level) => `Published Author trophy reached ${titleCase(level)}!`,
+  },
+  communityReader: {
+    thresholds: { bronze: 3, silver: 6, gold: 10, platinum: 20 },
+    rewards: { bronze: 15, silver: 30, gold: 75, platinum: 150 },
+    currencyLabel: "author gems",
+    message: (level) => `Community Reader trophy reached ${titleCase(level)}!`,
+  },
+};
+
+const titleCase = (value) => {
+  if (!value) return "";
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+};
+
+const ensurePopupQueue = (session) => {
+  if (!session) return null;
+  if (!Array.isArray(session.trophyPopups)) {
+    session.trophyPopups = [];
+  }
+  return session.trophyPopups;
+};
+
+const computeLevel = (value, thresholds) => {
+  const amount = Number(value) || 0;
+  if (!thresholds) return "none";
+  if (amount >= thresholds.platinum) return "platinum";
+  if (amount >= thresholds.gold) return "gold";
+  if (amount >= thresholds.silver) return "silver";
+  if (amount >= thresholds.bronze) return "bronze";
+  return "none";
+};
+
+const ensureTrophyContainer = (user) => {
+  if (!user.trophies) {
+    user.trophies = {};
+  }
+  ["storyBuilder", "publishedAuthor", "communityReader"].forEach((key) => {
+    if (!user.trophies[key]) {
+      user.trophies[key] = "none";
+    }
+  });
+};
+
+const ensureUserDoc = async (userOrId) => {
+  if (!userOrId) return null;
+  if (typeof userOrId === "object" && typeof userOrId.save === "function") {
+    return userOrId;
+  }
+  return User.findById(userOrId);
+};
+
+const applyTrophyProgress = ({ user, key, value, session }) => {
+  if (!user) {
+    return { changed: false, newLevel: "none", reward: 0, value: Number(value) || 0 };
+  }
+
+  const config = TROPHY_CONFIG[key];
+  if (!config) {
+    return { changed: false, newLevel: user.trophies?.[key] || "none", reward: 0, value: Number(value) || 0 };
+  }
+
+  ensureTrophyContainer(user);
+
+  const numericValue = Number(value) || 0;
+  const newLevel = computeLevel(numericValue, config.thresholds);
+  const previousLevel = user.trophies[key] || "none";
+  const previousIndex = LEVEL_ORDER.indexOf(previousLevel);
+  const nextIndex = LEVEL_ORDER.indexOf(newLevel);
+
+  if (nextIndex > previousIndex) {
+    user.trophies[key] = newLevel;
+    if (typeof user.markModified === "function") {
+      user.markModified("trophies");
+    }
+
+    const reward = Number(config.rewards?.[newLevel]) || 0;
+    if (reward > 0) {
+      user.authorCurrency = (Number(user.authorCurrency) || 0) + reward;
+    }
+
+    const queue = ensurePopupQueue(session);
+    if (queue && reward > 0) {
+      queue.push({
+        message: typeof config.message === "function"
+          ? config.message(newLevel, numericValue)
+          : `${titleCase(key.replace(/([A-Z])/g, " $1"))} trophy reached ${titleCase(newLevel)}!`,
+        amount: reward,
+        currencyLabel: config.currencyLabel || "coins",
+      });
+    }
+
+    return { changed: true, newLevel, reward, value: numericValue };
+  }
+
+  return { changed: false, newLevel: previousLevel, reward: 0, value: numericValue };
+};
+
+const updateStoryBuilderTrophy = async (userOrId, { session } = {}) => {
+  const user = await ensureUserDoc(userOrId);
+  if (!user) return { changed: false, newLevel: "none", reward: 0, value: 0 };
+  const count = await Story.countDocuments({ author: user._id, origin: "user" });
+  const result = applyTrophyProgress({ user, key: "storyBuilder", value: count, session });
+  return { ...result, user, value: count };
+};
+
+const updatePublishedAuthorTrophy = async (userOrId, { session } = {}) => {
+  const user = await ensureUserDoc(userOrId);
+  if (!user) return { changed: false, newLevel: "none", reward: 0, value: 0 };
+  const count = await Story.countDocuments({
+    author: user._id,
+    origin: "user",
+    status: "public",
+  });
+  const result = applyTrophyProgress({ user, key: "publishedAuthor", value: count, session });
+  return { ...result, user, value: count };
+};
+
+const updateCommunityReaderTrophy = async (userOrId, { session } = {}) => {
+  const user = await ensureUserDoc(userOrId);
+  if (!user) return { changed: false, newLevel: "none", reward: 0, value: 0 };
+
+  const progressEntries = Array.isArray(user.progress) ? user.progress : [];
+  const storyIds = Array.from(
+    new Set(
+      progressEntries
+        .map((entry) => {
+          const story = entry?.story;
+          if (!story) return null;
+          return typeof story === "object" && story._id ? String(story._id) : String(story);
+        })
+        .filter(Boolean)
+    )
+  );
+
+  if (storyIds.length === 0) {
+    ensureTrophyContainer(user);
+    return {
+      changed: false,
+      newLevel: user.trophies?.communityReader || "none",
+      reward: 0,
+      value: 0,
+    };
+  }
+
+  const stories = await Story.find({ _id: { $in: storyIds } })
+    .select("origin author")
+    .lean();
+  const userId = String(user._id);
+  const count = stories.filter((story) => {
+    if (!story || story.origin !== "user") return false;
+    if (!story.author) return true;
+    const authorId = typeof story.author === "object" && story.author._id
+      ? String(story.author._id)
+      : String(story.author);
+    return authorId !== userId;
+  }).length;
+
+  const result = applyTrophyProgress({ user, key: "communityReader", value: count, session });
+  return { ...result, user, value: count };
+};
+
+module.exports = {
+  TROPHY_CONFIG,
+  computeLevel,
+  ensurePopupQueue,
+  updateStoryBuilderTrophy,
+  updatePublishedAuthorTrophy,
+  updateCommunityReaderTrophy,
+};

--- a/views/admin/dashboard.ejs
+++ b/views/admin/dashboard.ejs
@@ -6,8 +6,14 @@
   <body>
     <%- include('../partials/header', { user }) %>
 
-    <main class="container">
+    <main class="container admin-dashboard">
       <h1 class="title">Admin Dashboard</h1>
+
+      <% if (flash && flash.message) { %>
+      <div class="flash flash-<%= flash.type === 'error' ? 'error' : 'success' %>">
+        <%= flash.message %>
+      </div>
+      <% } %>
 
       <section class="stats-grid">
         <div class="stat-card">
@@ -27,8 +33,269 @@
           >Upload Story Seed</a
         >
       </section>
+
+      <section class="review-section">
+        <header class="review-header">
+          <h2>Pending user stories</h2>
+          <p class="muted">
+            Review community submissions and decide whether they are ready for
+            the public library.
+          </p>
+        </header>
+
+        <% if (!pendingStories || pendingStories.length === 0) { %>
+        <p class="muted">No stories are awaiting review.</p>
+        <% } else { %>
+        <div class="review-grid">
+          <% pendingStories.forEach(function (story) { %>
+          <article class="review-card">
+            <header class="review-card__header">
+              <h3><%= story.title %></h3>
+              <span class="story-status story-status-<%= story.status %>">
+                <%= story.statusLabel %>
+              </span>
+            </header>
+            <p class="muted">
+              Submitted by
+              <strong><%= story.author?.username || 'Unknown author' %></strong>
+              on
+              <%= story.submittedAt
+                ? new Date(story.submittedAt).toLocaleString()
+                : new Date(story.updatedAt || story.createdAt).toLocaleString() %>
+            </p>
+            <div class="review-card__actions">
+              <a class="cta-button small ghost" href="/u/story/<%= story._id %>"
+                >Preview</a
+              >
+              <form
+                method="post"
+                action="/admin/user-stories/<%= story._id %>/approve"
+                class="inline-form"
+              >
+                <button type="submit" class="cta-button small">Approve</button>
+              </form>
+              <form
+                method="post"
+                action="/admin/user-stories/<%= story._id %>/under-review"
+                class="inline-form"
+              >
+                <button type="submit" class="cta-button small ghost">
+                  Mark under review
+                </button>
+              </form>
+              <form
+                method="post"
+                action="/admin/user-stories/<%= story._id %>/reject"
+                class="inline-form"
+              >
+                <button type="submit" class="cta-button small danger">
+                  Reject
+                </button>
+              </form>
+            </div>
+          </article>
+          <% }) %>
+        </div>
+        <% } %>
+      </section>
+
+      <section class="review-section">
+        <header class="review-header">
+          <h2>Published & under-review user stories</h2>
+          <p class="muted">
+            Use these tools to temporarily pull stories from the public library
+            or return them once issues are resolved.
+          </p>
+        </header>
+
+        <% if (!managedStories || managedStories.length === 0) { %>
+        <p class="muted">No published community stories need attention.</p>
+        <% } else { %>
+        <div class="review-grid">
+          <% managedStories.forEach(function (story) { %>
+          <article class="review-card">
+            <header class="review-card__header">
+              <h3><%= story.title %></h3>
+              <span class="story-status story-status-<%= story.status %>">
+                <%= story.statusLabel %>
+              </span>
+            </header>
+            <p class="muted">
+              Author:
+              <strong><%= story.author?.username || 'Unknown author' %></strong>
+            </p>
+            <div class="review-card__actions">
+              <a class="cta-button small ghost" href="/u/story/<%= story._id %>"
+                >Preview</a
+              >
+              <% if (story.status === 'under_review') { %>
+              <form
+                method="post"
+                action="/admin/user-stories/<%= story._id %>/approve"
+                class="inline-form"
+              >
+                <button type="submit" class="cta-button small">Publish</button>
+              </form>
+              <% } else { %>
+              <form
+                method="post"
+                action="/admin/user-stories/<%= story._id %>/under-review"
+                class="inline-form"
+              >
+                <button type="submit" class="cta-button small ghost">
+                  Mark under review
+                </button>
+              </form>
+              <% } %>
+              <form
+                method="post"
+                action="/admin/user-stories/<%= story._id %>/remove"
+                class="inline-form"
+              >
+                <button type="submit" class="cta-button small danger">
+                  Remove from public
+                </button>
+              </form>
+            </div>
+          </article>
+          <% }) %>
+        </div>
+        <% } %>
+      </section>
     </main>
 
     <%- include('../partials/footer') %>
+
+    <style>
+      .admin-dashboard {
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+        padding-bottom: 4rem;
+      }
+
+      .flash {
+        padding: 0.9rem 1.1rem;
+        border-radius: 12px;
+        font-weight: 600;
+      }
+
+      .flash-success {
+        background: rgba(34, 197, 94, 0.12);
+        border: 1px solid rgba(34, 197, 94, 0.3);
+        color: #bbf7d0;
+      }
+
+      .flash-error {
+        background: rgba(248, 113, 113, 0.12);
+        border: 1px solid rgba(248, 113, 113, 0.3);
+        color: #fecaca;
+      }
+
+      .review-section {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .review-header h2 {
+        margin: 0;
+      }
+
+      .review-grid {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .review-card {
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 16px;
+        padding: 1.25rem;
+        background: rgba(15, 23, 42, 0.75);
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+      }
+
+      .review-card__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      .review-card__header h3 {
+        margin: 0;
+        font-size: 1.15rem;
+      }
+
+      .review-card__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+      }
+
+      .review-card__actions .inline-form {
+        margin: 0;
+      }
+
+      .story-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.3rem 0.75rem;
+        border-radius: 999px;
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(148, 163, 184, 0.12);
+        color: #e2e8f0;
+      }
+
+      .story-status-public {
+        background: rgba(34, 197, 94, 0.15);
+        border-color: rgba(34, 197, 94, 0.3);
+        color: #bbf7d0;
+      }
+
+      .story-status-pending,
+      .story-status-coming_soon {
+        background: rgba(59, 130, 246, 0.18);
+        border-color: rgba(59, 130, 246, 0.32);
+        color: #bfdbfe;
+      }
+
+      .story-status-under_review {
+        background: rgba(244, 114, 182, 0.2);
+        border-color: rgba(244, 114, 182, 0.35);
+        color: #fbcfe8;
+      }
+
+      .story-status-private {
+        background: rgba(148, 163, 184, 0.12);
+        border-color: rgba(148, 163, 184, 0.32);
+        color: #cbd5f5;
+      }
+
+      .cta-button.small.danger {
+        background: #7f1d1d;
+      }
+
+      .cta-button.small.danger:hover {
+        background: #b91c1c;
+      }
+
+      @media (max-width: 720px) {
+        .review-card__header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .review-card__actions {
+          flex-direction: column;
+          align-items: stretch;
+        }
+      }
+    </style>
   </body>
 </html>

--- a/views/admin/dashboard.ejs
+++ b/views/admin/dashboard.ejs
@@ -38,13 +38,60 @@
         <header class="review-header">
           <h2>Pending user stories</h2>
           <p class="muted">
-            Review community submissions and decide whether they are ready for
-            the public library.
+            Review new submissions and decide whether they are ready for the
+            community library.
           </p>
         </header>
 
+        <form method="get" class="filter-form">
+          <div class="filter-form__row">
+            <label class="filter-field">
+              <span class="filter-label">Search</span>
+              <input
+                type="search"
+                name="pendingSearch"
+                value="<%= filters.pending.search %>"
+                placeholder="Search by title or author"
+              />
+            </label>
+            <label class="filter-field">
+              <span class="filter-label">Categories</span>
+              <select name="pendingCategories" multiple size="5">
+                <% categories.forEach(function (cat) { %>
+                <option
+                  value="<%= cat %>"
+                  <%= filters.pending.categories.includes(cat) ? 'selected' : '' %>
+                >
+                  <%= cat %>
+                </option>
+                <% }) %>
+              </select>
+            </label>
+          </div>
+          <div class="filter-form__actions">
+            <button type="submit" class="btn small">Apply filters</button>
+            <a href="/admin" class="btn small ghost">Reset</a>
+          </div>
+          <input
+            type="hidden"
+            name="underReviewSearch"
+            value="<%= filters.underReview.search %>"
+          />
+          <% filters.underReview.categories.forEach(function (cat) { %>
+          <input type="hidden" name="underReviewCategories" value="<%= cat %>" />
+          <% }) %>
+          <input
+            type="hidden"
+            name="publishedSearch"
+            value="<%= filters.published.search %>"
+          />
+          <% filters.published.categories.forEach(function (cat) { %>
+          <input type="hidden" name="publishedCategories" value="<%= cat %>" />
+          <% }) %>
+        </form>
+
         <% if (!pendingStories || pendingStories.length === 0) { %>
-        <p class="muted">No stories are awaiting review.</p>
+        <p class="muted empty-message">No pending stories match your filters.</p>
         <% } else { %>
         <div class="review-grid">
           <% pendingStories.forEach(function (story) { %>
@@ -57,14 +104,22 @@
             </header>
             <p class="muted">
               Submitted by
-              <strong><%= story.author?.username || 'Unknown author' %></strong>
-              on
+              <strong><%= story.authorName %></strong>
               <%= story.submittedAt
-                ? new Date(story.submittedAt).toLocaleString()
-                : new Date(story.updatedAt || story.createdAt).toLocaleString() %>
+                ? `on ${new Date(story.submittedAt).toLocaleString()}`
+                : '' %>
             </p>
+            <% if (story.categories && story.categories.length) { %>
+            <ul class="story-tag-list">
+              <% story.categories.forEach(function (cat) { %>
+              <li class="story-tag"><%= cat %></li>
+              <% }) %>
+            </ul>
+            <% } %>
             <div class="review-card__actions">
-              <a class="cta-button small ghost" href="/u/story/<%= story._id %>"
+              <a
+                class="cta-button small ghost"
+                href="/u/story/<%= story._id %>?adminPreview=1&return=<%= encodedReturnTo %>"
                 >Preview</a
               >
               <form
@@ -93,6 +148,33 @@
                 </button>
               </form>
             </div>
+            <form
+              class="note-form"
+              method="post"
+              action="/admin/user-stories/<%= story._id %>/note"
+            >
+              <label class="sr-only" for="pending-note-<%= story._id %>">Review note</label>
+              <textarea
+                id="pending-note-<%= story._id %>"
+                name="reviewNote"
+                rows="3"
+                placeholder="Leave a note for the author"
+              ><%= story.reviewNote || '' %></textarea>
+              <input type="hidden" name="returnTo" value="<%= currentQuery %>" />
+              <div class="note-form__actions">
+                <button type="submit" class="btn small">Save note</button>
+                <% if (story.reviewNote) { %>
+                <button
+                  type="submit"
+                  name="clearNote"
+                  value="1"
+                  class="btn small ghost"
+                >
+                  Remove note
+                </button>
+                <% } %>
+              </div>
+            </form>
           </article>
           <% }) %>
         </div>
@@ -101,18 +183,65 @@
 
       <section class="review-section">
         <header class="review-header">
-          <h2>Published & under-review user stories</h2>
+          <h2>Stories under review</h2>
           <p class="muted">
-            Use these tools to temporarily pull stories from the public library
-            or return them once issues are resolved.
+            Follow up on stories pulled for edits and publish them once issues
+            are resolved.
           </p>
         </header>
 
-        <% if (!managedStories || managedStories.length === 0) { %>
-        <p class="muted">No published community stories need attention.</p>
+        <form method="get" class="filter-form">
+          <div class="filter-form__row">
+            <label class="filter-field">
+              <span class="filter-label">Search</span>
+              <input
+                type="search"
+                name="underReviewSearch"
+                value="<%= filters.underReview.search %>"
+                placeholder="Search by title or author"
+              />
+            </label>
+            <label class="filter-field">
+              <span class="filter-label">Categories</span>
+              <select name="underReviewCategories" multiple size="5">
+                <% categories.forEach(function (cat) { %>
+                <option
+                  value="<%= cat %>"
+                  <%= filters.underReview.categories.includes(cat) ? 'selected' : '' %>
+                >
+                  <%= cat %>
+                </option>
+                <% }) %>
+              </select>
+            </label>
+          </div>
+          <div class="filter-form__actions">
+            <button type="submit" class="btn small">Apply filters</button>
+            <a href="/admin" class="btn small ghost">Reset</a>
+          </div>
+          <input
+            type="hidden"
+            name="pendingSearch"
+            value="<%= filters.pending.search %>"
+          />
+          <% filters.pending.categories.forEach(function (cat) { %>
+          <input type="hidden" name="pendingCategories" value="<%= cat %>" />
+          <% }) %>
+          <input
+            type="hidden"
+            name="publishedSearch"
+            value="<%= filters.published.search %>"
+          />
+          <% filters.published.categories.forEach(function (cat) { %>
+          <input type="hidden" name="publishedCategories" value="<%= cat %>" />
+          <% }) %>
+        </form>
+
+        <% if (!underReviewStories || underReviewStories.length === 0) { %>
+        <p class="muted empty-message">No stories are currently under review.</p>
         <% } else { %>
         <div class="review-grid">
-          <% managedStories.forEach(function (story) { %>
+          <% underReviewStories.forEach(function (story) { %>
           <article class="review-card">
             <header class="review-card__header">
               <h3><%= story.title %></h3>
@@ -121,14 +250,21 @@
               </span>
             </header>
             <p class="muted">
-              Author:
-              <strong><%= story.author?.username || 'Unknown author' %></strong>
+              Author: <strong><%= story.authorName %></strong>
             </p>
+            <% if (story.categories && story.categories.length) { %>
+            <ul class="story-tag-list">
+              <% story.categories.forEach(function (cat) { %>
+              <li class="story-tag"><%= cat %></li>
+              <% }) %>
+            </ul>
+            <% } %>
             <div class="review-card__actions">
-              <a class="cta-button small ghost" href="/u/story/<%= story._id %>"
+              <a
+                class="cta-button small ghost"
+                href="/u/story/<%= story._id %>?adminPreview=1&return=<%= encodedReturnTo %>"
                 >Preview</a
               >
-              <% if (story.status === 'under_review') { %>
               <form
                 method="post"
                 action="/admin/user-stories/<%= story._id %>/approve"
@@ -136,17 +272,6 @@
               >
                 <button type="submit" class="cta-button small">Publish</button>
               </form>
-              <% } else { %>
-              <form
-                method="post"
-                action="/admin/user-stories/<%= story._id %>/under-review"
-                class="inline-form"
-              >
-                <button type="submit" class="cta-button small ghost">
-                  Mark under review
-                </button>
-              </form>
-              <% } %>
               <form
                 method="post"
                 action="/admin/user-stories/<%= story._id %>/remove"
@@ -157,6 +282,173 @@
                 </button>
               </form>
             </div>
+            <form
+              class="note-form"
+              method="post"
+              action="/admin/user-stories/<%= story._id %>/note"
+            >
+              <label class="sr-only" for="under-review-note-<%= story._id %>"
+                >Review note</label
+              >
+              <textarea
+                id="under-review-note-<%= story._id %>"
+                name="reviewNote"
+                rows="3"
+                placeholder="Leave a note for the author"
+              ><%= story.reviewNote || '' %></textarea>
+              <input type="hidden" name="returnTo" value="<%= currentQuery %>" />
+              <div class="note-form__actions">
+                <button type="submit" class="btn small">Save note</button>
+                <% if (story.reviewNote) { %>
+                <button
+                  type="submit"
+                  name="clearNote"
+                  value="1"
+                  class="btn small ghost"
+                >
+                  Remove note
+                </button>
+                <% } %>
+              </div>
+            </form>
+          </article>
+          <% }) %>
+        </div>
+        <% } %>
+      </section>
+
+      <section class="review-section">
+        <header class="review-header">
+          <h2>Published user stories</h2>
+          <p class="muted">
+            Search and filter public community stories. Pull a story for edits or
+            remove it from the library if necessary.
+          </p>
+        </header>
+
+        <form method="get" class="filter-form">
+          <div class="filter-form__row">
+            <label class="filter-field">
+              <span class="filter-label">Search</span>
+              <input
+                type="search"
+                name="publishedSearch"
+                value="<%= filters.published.search %>"
+                placeholder="Search by title or author"
+              />
+            </label>
+            <label class="filter-field">
+              <span class="filter-label">Categories</span>
+              <select name="publishedCategories" multiple size="5">
+                <% categories.forEach(function (cat) { %>
+                <option
+                  value="<%= cat %>"
+                  <%= filters.published.categories.includes(cat) ? 'selected' : '' %>
+                >
+                  <%= cat %>
+                </option>
+                <% }) %>
+              </select>
+            </label>
+          </div>
+          <div class="filter-form__actions">
+            <button type="submit" class="btn small">Apply filters</button>
+            <a href="/admin" class="btn small ghost">Reset</a>
+          </div>
+          <input
+            type="hidden"
+            name="pendingSearch"
+            value="<%= filters.pending.search %>"
+          />
+          <% filters.pending.categories.forEach(function (cat) { %>
+          <input type="hidden" name="pendingCategories" value="<%= cat %>" />
+          <% }) %>
+          <input
+            type="hidden"
+            name="underReviewSearch"
+            value="<%= filters.underReview.search %>"
+          />
+          <% filters.underReview.categories.forEach(function (cat) { %>
+          <input type="hidden" name="underReviewCategories" value="<%= cat %>" />
+          <% }) %>
+        </form>
+
+        <% if (!publishedStories || publishedStories.length === 0) { %>
+        <p class="muted empty-message">No published stories match your filters.</p>
+        <% } else { %>
+        <div class="review-grid">
+          <% publishedStories.forEach(function (story) { %>
+          <article class="review-card">
+            <header class="review-card__header">
+              <h3><%= story.title %></h3>
+              <span class="story-status story-status-<%= story.status %>">
+                <%= story.statusLabel %>
+              </span>
+            </header>
+            <p class="muted">
+              Author: <strong><%= story.authorName %></strong>
+            </p>
+            <% if (story.categories && story.categories.length) { %>
+            <ul class="story-tag-list">
+              <% story.categories.forEach(function (cat) { %>
+              <li class="story-tag"><%= cat %></li>
+              <% }) %>
+            </ul>
+            <% } %>
+            <div class="review-card__actions">
+              <a
+                class="cta-button small ghost"
+                href="/u/story/<%= story._id %>?adminPreview=1&return=<%= encodedReturnTo %>"
+                >Preview</a
+              >
+              <form
+                method="post"
+                action="/admin/user-stories/<%= story._id %>/under-review"
+                class="inline-form"
+              >
+                <button type="submit" class="cta-button small ghost">
+                  Mark under review
+                </button>
+              </form>
+              <form
+                method="post"
+                action="/admin/user-stories/<%= story._id %>/remove"
+                class="inline-form"
+              >
+                <button type="submit" class="cta-button small danger">
+                  Remove from public
+                </button>
+              </form>
+            </div>
+            <form
+              class="note-form"
+              method="post"
+              action="/admin/user-stories/<%= story._id %>/note"
+            >
+              <label class="sr-only" for="published-note-<%= story._id %>"
+                >Review note</label
+              >
+              <textarea
+                id="published-note-<%= story._id %>"
+                name="reviewNote"
+                rows="3"
+                placeholder="Leave a note for the author"
+              ><%= story.reviewNote || '' %></textarea>
+              <input type="hidden" name="returnTo" value="<%= currentQuery %>" />
+              <div class="note-form__actions">
+                <button type="submit" class="btn small">Save note</button>
+                <% if (story.reviewNote) { %>
+                <button
+                  type="submit"
+                  name="clearNote"
+                  value="1"
+                  class="btn small ghost"
+                >
+                  Remove note
+                </button>
+                <% } %>
+              </div>
+            </form>
           </article>
           <% }) %>
         </div>
@@ -215,6 +507,112 @@
         display: flex;
         flex-direction: column;
         gap: 0.85rem;
+      }
+
+      .filter-form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 0.75rem 1rem;
+        border-radius: 14px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        background: rgba(15, 23, 42, 0.65);
+      }
+
+      .filter-form__row {
+        display: grid;
+        gap: 0.75rem;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+
+      .filter-field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        color: rgba(203, 213, 225, 0.8);
+      }
+
+      .filter-field input,
+      .filter-field select,
+      .note-form textarea {
+        width: 100%;
+        border-radius: 10px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        background: rgba(15, 23, 42, 0.9);
+        color: #f8fafc;
+        padding: 0.55rem 0.75rem;
+        font-size: 0.95rem;
+      }
+
+      .filter-field select {
+        min-height: 7.5rem;
+      }
+
+      .filter-form__actions {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+
+      .filter-label {
+        font-size: 0.78rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(148, 163, 184, 0.8);
+      }
+
+      .empty-message {
+        font-size: 0.9rem;
+        color: rgba(148, 163, 184, 0.85);
+      }
+
+      .story-tag-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .story-tag {
+        padding: 0.25rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        background: rgba(59, 130, 246, 0.2);
+        border: 1px solid rgba(59, 130, 246, 0.32);
+        color: #dbeafe;
+      }
+
+      .note-form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+        margin-top: 0.25rem;
+      }
+
+      .note-form textarea {
+        resize: vertical;
+        min-height: 5.5rem;
+      }
+
+      .note-form__actions {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
       }
 
       .review-card__header {

--- a/views/admin/stories.ejs
+++ b/views/admin/stories.ejs
@@ -115,12 +115,38 @@
         color: #cbd5f5;
         font-style: italic;
       }
+
+      .admin-status.status-private {
+        background: rgba(148, 163, 184, 0.12);
+        border-color: rgba(148, 163, 184, 0.32);
+        color: #e2e8f0;
+      }
+
+      .admin-status.status-pending {
+        background: rgba(59, 130, 246, 0.18);
+        border-color: rgba(59, 130, 246, 0.32);
+        color: #bfdbfe;
+      }
+
+      .admin-status.status-under_review {
+        background: rgba(244, 114, 182, 0.2);
+        border-color: rgba(244, 114, 182, 0.35);
+        color: #fbcfe8;
+      }
     </style>
   </head>
   <body>
     <%- include('../partials/header', { user }) %>
 
     <main class="container">
+      <% const statusLabels = {
+        public: 'Public',
+        coming_soon: 'Coming Soon',
+        invisible: 'Hidden',
+        private: 'Private',
+        pending: 'Pending Review',
+        under_review: 'Under Review'
+      }; %>
       <h1 class="title">Manage Stories</h1>
 
       <div class="stories-toolbar">
@@ -148,11 +174,7 @@
             <div class="story-card__meta">
               <span class="admin-status status-<%= s.status %>">
                 Status:
-                <%= s.status === 'public'
-                  ? 'Public'
-                  : s.status === 'coming_soon'
-                  ? 'Coming Soon'
-                  : 'Invisible' %>
+                <%= statusLabels[s.status] || s.status %>
               </span>
             </div>
 

--- a/views/admin/storyEditor.ejs
+++ b/views/admin/storyEditor.ejs
@@ -712,6 +712,9 @@
             <option value="public" <%= story.status === 'public' ? 'selected' : '' %>>Public</option>
             <option value="coming_soon" <%= story.status === 'coming_soon' ? 'selected' : '' %>>Coming Soon</option>
             <option value="invisible" <%= story.status === 'invisible' ? 'selected' : '' %>>Invisible</option>
+            <option value="pending" <%= story.status === 'pending' ? 'selected' : '' %>>Pending Review</option>
+            <option value="under_review" <%= story.status === 'under_review' ? 'selected' : '' %>>Under Review</option>
+            <option value="private" <%= story.status === 'private' ? 'selected' : '' %>>Private</option>
           </select>
         </label>
         <label class="field">

--- a/views/admin/userDetail.ejs
+++ b/views/admin/userDetail.ejs
@@ -33,6 +33,9 @@
 
           <label>Currency</label>
           <input type="number" name="currency" value="<%= user.currency || 0 %>">
+
+          <label>Author Gems</label>
+          <input type="number" name="authorCurrency" value="<%= user.authorCurrency || 0 %>">
         </fieldset>
 
         <fieldset>

--- a/views/admin/userLibrary.ejs
+++ b/views/admin/userLibrary.ejs
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <%- include('../partials/head') %>
+  </head>
+  <body>
+    <%- include('../partials/header', { user: adminUser }) %>
+
+    <main class="container admin-author-library">
+      <div class="top-actions">
+        <a href="/admin/users" class="back-link">&larr; Back to Users</a>
+      </div>
+
+      <h1 class="title"><%= author.username %>'s Author Library</h1>
+      <p class="muted intro">
+        Review the drafts and published stories that belong to this author. Use
+        the admin dashboard to approve, reject, or remove submissions.
+      </p>
+
+      <% if (!stories || stories.length === 0) { %>
+      <section class="empty-state">
+        <p>This author hasn't created any stories yet.</p>
+        <p class="muted">Stories will appear here once they start building.</p>
+      </section>
+      <% } else { %>
+      <section class="story-grid">
+        <% stories.forEach(function (story) { const coverSrc = story.coverImage || '/images/default-cover.svg'; %>
+        <article class="story-card">
+          <div class="story-card__media">
+            <img src="<%= coverSrc %>" alt="Cover for <%= story.title %>" loading="lazy" />
+          </div>
+          <div class="story-card__body">
+            <header class="story-card__header">
+              <h2><%= story.title %></h2>
+              <span class="story-status story-status-<%= story.status %>">
+                <%= story.statusLabel %>
+              </span>
+            </header>
+            <dl class="story-card__meta">
+              <div>
+                <dt>Updated</dt>
+                <dd><%= story.updatedAt ? new Date(story.updatedAt).toLocaleString() : '—' %></dd>
+              </div>
+              <div>
+                <dt>Created</dt>
+                <dd><%= story.createdAt ? new Date(story.createdAt).toLocaleDateString() : '—' %></dd>
+              </div>
+              <% if (story.submittedAt) { %>
+              <div>
+                <dt>Submitted</dt>
+                <dd><%= new Date(story.submittedAt).toLocaleDateString() %></dd>
+              </div>
+              <% } %>
+              <% if (story.publishedAt) { %>
+              <div>
+                <dt>Published</dt>
+                <dd><%= new Date(story.publishedAt).toLocaleDateString() %></dd>
+              </div>
+              <% } %>
+            </dl>
+            <div class="story-card__actions">
+              <a class="cta-button small ghost" href="/u/story/<%= story._id %>"
+                >Preview Story</a
+              >
+              <% if (story.isPending || story.isUnderReview) { %>
+              <span class="review-note">Awaiting admin review</span>
+              <% } %>
+              <% if (story.isPublic) { %>
+              <span class="review-note">Live in public library</span>
+              <% } %>
+            </div>
+          </div>
+        </article>
+        <% }) %>
+      </section>
+      <% } %>
+    </main>
+
+    <%- include('../partials/footer') %>
+
+    <style>
+      .admin-author-library {
+        display: flex;
+        flex-direction: column;
+        gap: 1.75rem;
+        padding-bottom: 3rem;
+      }
+
+      .top-actions {
+        margin-top: 1rem;
+      }
+
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.35rem 0.75rem;
+        border-radius: 999px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        color: #e5e7eb;
+        text-decoration: none;
+        font-size: 0.9rem;
+        transition: background 0.2s ease, color 0.2s ease;
+        background: rgba(148, 163, 184, 0.12);
+      }
+
+      .back-link:hover {
+        background: rgba(148, 163, 184, 0.22);
+      }
+
+      .intro {
+        max-width: 640px;
+      }
+
+      .story-grid {
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .story-card {
+        display: grid;
+        grid-template-columns: minmax(140px, 180px) 1fr;
+        gap: 1.5rem;
+        padding: 1.25rem 1.5rem;
+        border-radius: 18px;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        background: rgba(15, 23, 42, 0.86);
+      }
+
+      .story-card__media {
+        border-radius: 14px;
+        overflow: hidden;
+        background: rgba(15, 23, 42, 0.72);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .story-card__media img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+
+      .story-card__body {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .story-card__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 1rem;
+      }
+
+      .story-card__header h2 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .story-card__meta {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 0.75rem 1.25rem;
+        margin: 0;
+      }
+
+      .story-card__meta dt {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: rgba(203, 213, 225, 0.8);
+      }
+
+      .story-card__meta dd {
+        margin: 0.15rem 0 0;
+        font-size: 0.95rem;
+      }
+
+      .story-card__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        align-items: center;
+      }
+
+      .review-note {
+        font-size: 0.8rem;
+        color: rgba(148, 163, 184, 0.9);
+        background: rgba(30, 41, 59, 0.6);
+        border-radius: 999px;
+        padding: 0.25rem 0.75rem;
+      }
+
+      .empty-state {
+        padding: 2rem;
+        border-radius: 18px;
+        border: 1px dashed rgba(148, 163, 184, 0.3);
+        text-align: center;
+        background: rgba(15, 23, 42, 0.7);
+      }
+    </style>
+  </body>
+</html>

--- a/views/admin/userLibrary.ejs
+++ b/views/admin/userLibrary.ejs
@@ -58,8 +58,16 @@
               </div>
               <% } %>
             </dl>
+            <% if (story.reviewNote) { %>
+            <div class="story-card__note">
+              <strong>Note for author</strong>
+              <p><%= story.reviewNote %></p>
+            </div>
+            <% } %>
             <div class="story-card__actions">
-              <a class="cta-button small ghost" href="/u/story/<%= story._id %>"
+              <a
+                class="cta-button small ghost"
+                href="/u/story/<%= story._id %>?adminPreview=1&return=<%= encodedReturnTo %>"
                 >Preview Story</a
               >
               <% if (story.isPending || story.isUnderReview) { %>
@@ -184,6 +192,30 @@
         flex-wrap: wrap;
         gap: 0.5rem;
         align-items: center;
+      }
+
+      .story-card__note {
+        margin-top: 1rem;
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        border: 1px solid rgba(96, 165, 250, 0.3);
+        background: rgba(59, 130, 246, 0.12);
+        color: #e2e8f0;
+      }
+
+      .story-card__note strong {
+        display: block;
+        margin-bottom: 0.35rem;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: rgba(96, 165, 250, 0.85);
+      }
+
+      .story-card__note p {
+        margin: 0;
+        font-size: 0.9rem;
+        line-height: 1.45;
       }
 
       .review-note {

--- a/views/admin/users.ejs
+++ b/views/admin/users.ejs
@@ -35,6 +35,7 @@
             <th>Email</th>
             <th>Role</th>
             <th>Currency</th>
+            <th>Author Gems</th>
             <th>Actions</th>
           </tr>
         </thead>
@@ -45,6 +46,7 @@
             <td><%= u.email %></td>
             <td><%= u.role %></td>
             <td><%= u.currency || 0 %></td>
+            <td><%= u.authorCurrency || 0 %></td>
             <td class="actions">
               <a href="/admin/users/<%= u._id %>" class="cta-button small"
                 >View</a

--- a/views/admin/users.ejs
+++ b/views/admin/users.ejs
@@ -48,6 +48,9 @@
             <td><%= u.currency || 0 %></td>
             <td><%= u.authorCurrency || 0 %></td>
             <td class="actions">
+              <a href="/admin/users/<%= u._id %>/library" class="cta-button small ghost"
+                >Author Library</a
+              >
               <a href="/admin/users/<%= u._id %>" class="cta-button small"
                 >View</a
               >

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,6 +1,17 @@
 <header class="site-header">
   <h1>Shadow Paths</h1>
-  <nav class="top-nav">
+  <button
+    class="menu-toggle"
+    type="button"
+    aria-expanded="false"
+    aria-controls="primary-navigation"
+  >
+    <span class="sr-only">Toggle navigation</span>
+    <span class="menu-toggle__bar" aria-hidden="true"></span>
+    <span class="menu-toggle__bar" aria-hidden="true"></span>
+    <span class="menu-toggle__bar" aria-hidden="true"></span>
+  </button>
+  <nav class="top-nav" id="primary-navigation" data-visible="true">
     <a href="/">Home</a>
     <a href="/u/library">Library</a>
     <a href="/about">About</a>
@@ -23,3 +34,24 @@
     <% } %>
   </nav>
 </header>
+<script>
+  (() => {
+    const toggle = document.querySelector('.menu-toggle');
+    const nav = document.getElementById('primary-navigation');
+    if (!toggle || !nav) {
+      return;
+    }
+
+    const setState = (expanded) => {
+      toggle.setAttribute('aria-expanded', String(expanded));
+      nav.dataset.visible = String(expanded);
+    };
+
+    setState(false);
+
+    toggle.addEventListener('click', () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      setState(!expanded);
+    });
+  })();
+</script>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -7,6 +7,7 @@
 
     <% if (user) { %>
     <a href="/u/stats">My Stats</a>
+    <a href="/u/authors">Authors</a>
 
     <% if (user.role === 'admin') { %>
     <a href="/admin">Admin</a>

--- a/views/user/authorDashboard.ejs
+++ b/views/user/authorDashboard.ejs
@@ -113,6 +113,12 @@
               </form>
               <% } %>
             </div>
+            <% if (story.reviewNote) { %>
+            <div class="author-story-card__note">
+              <strong>Admin note:</strong>
+              <p><%= story.reviewNote %></p>
+            </div>
+            <% } %>
           </div>
         </article>
         <% }) %>
@@ -264,6 +270,30 @@
 
       .author-story-card__actions .inline-form {
         margin: 0;
+      }
+
+      .author-story-card__note {
+        margin-top: 1rem;
+        padding: 0.85rem 1rem;
+        border-radius: 12px;
+        border: 1px solid rgba(244, 114, 182, 0.25);
+        background: rgba(244, 114, 182, 0.08);
+        color: #f8fafc;
+      }
+
+      .author-story-card__note strong {
+        display: block;
+        margin-bottom: 0.35rem;
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(244, 114, 182, 0.9);
+      }
+
+      .author-story-card__note p {
+        margin: 0;
+        font-size: 0.9rem;
+        line-height: 1.4;
       }
 
       .story-status {

--- a/views/user/authorDashboard.ejs
+++ b/views/user/authorDashboard.ejs
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <%- include('../partials/head') %>
+  </head>
+  <body>
+    <%- include('../partials/header', { user }) %>
+
+    <main class="container author-dashboard">
+      <h1 class="title">My Author Library</h1>
+
+      <% if (flash && flash.message) { %>
+      <div class="flash flash-<%= flash.type === 'error' ? 'error' : 'success' %>">
+        <%= flash.message %>
+      </div>
+      <% } %>
+
+      <div class="author-dashboard__intro">
+        <p>
+          Craft new adventures and manage the stories you've built with the
+          Shadow Paths story builder. Submit drafts for review when you're ready
+          to share them with the community.
+        </p>
+        <a class="cta-button" href="/u/authors/stories/new">+ Create a new story</a>
+      </div>
+
+      <% if (!stories || stories.length === 0) { %>
+      <section class="empty-state">
+        <p>You haven't created any stories yet.</p>
+        <p class="muted">Use the button above to start your first tale.</p>
+      </section>
+      <% } else { %>
+      <section class="author-stories">
+        <% stories.forEach(function (story) { %>
+        <article class="author-story-card">
+          <header class="author-story-card__header">
+            <h2><%= story.title %></h2>
+            <span class="story-status story-status-<%= story.status %>">
+              <%= story.statusLabel %>
+            </span>
+          </header>
+          <dl class="author-story-card__meta">
+            <div>
+              <dt>Last updated</dt>
+              <dd><%= story.updatedAt ? new Date(story.updatedAt).toLocaleString() : '—' %></dd>
+            </div>
+            <div>
+              <dt>Created</dt>
+              <dd><%= story.createdAt ? new Date(story.createdAt).toLocaleDateString() : '—' %></dd>
+            </div>
+            <% if (story.submittedAt) { %>
+            <div>
+              <dt>Submitted</dt>
+              <dd><%= new Date(story.submittedAt).toLocaleDateString() %></dd>
+            </div>
+            <% } %>
+            <% if (story.publishedAt) { %>
+            <div>
+              <dt>Published</dt>
+              <dd><%= new Date(story.publishedAt).toLocaleDateString() %></dd>
+            </div>
+            <% } %>
+          </dl>
+          <div class="author-story-card__actions">
+            <a class="cta-button small" href="/u/authors/stories/<%= story._id %>/edit"
+              >Edit draft</a
+            >
+            <a class="cta-button small ghost" href="/u/story/<%= story._id %>"
+              >Preview story</a
+            >
+            <% if (story.isPrivate) { %>
+            <form
+              method="post"
+              action="/u/authors/stories/<%= story._id %>/submit"
+              class="inline-form"
+            >
+              <button type="submit" class="cta-button small">Submit for review</button>
+            </form>
+            <% } %>
+            <% if (story.isPending || story.isUnderReview || story.isPublic) { %>
+            <form
+              method="post"
+              action="/u/authors/stories/<%= story._id %>/private"
+              class="inline-form"
+            >
+              <button type="submit" class="cta-button small ghost">
+                Set to private
+              </button>
+            </form>
+            <% } %>
+          </div>
+        </article>
+        <% }) %>
+      </section>
+      <% } %>
+    </main>
+
+    <%- include('../partials/footer') %>
+
+    <style>
+      .author-dashboard {
+        padding-bottom: 4rem;
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+      }
+
+      .author-dashboard__intro {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 1.5rem;
+        border-radius: 16px;
+        background: rgba(30, 41, 59, 0.55);
+        border: 1px solid rgba(148, 163, 184, 0.18);
+      }
+
+      .author-dashboard__intro p {
+        flex: 1 1 260px;
+        margin: 0;
+        color: #cbd5f5;
+      }
+
+      .flash {
+        padding: 0.95rem 1.2rem;
+        border-radius: 14px;
+        font-weight: 600;
+      }
+
+      .flash-success {
+        background: rgba(34, 197, 94, 0.12);
+        border: 1px solid rgba(34, 197, 94, 0.28);
+        color: #bbf7d0;
+      }
+
+      .flash-error {
+        background: rgba(248, 113, 113, 0.12);
+        border: 1px solid rgba(248, 113, 113, 0.28);
+        color: #fecaca;
+      }
+
+      .author-stories {
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .author-story-card {
+        background: rgba(17, 24, 39, 0.85);
+        border: 1px solid rgba(148, 163, 184, 0.15);
+        border-radius: 18px;
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.2rem;
+      }
+
+      .author-story-card__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      .author-story-card__header h2 {
+        margin: 0;
+        font-size: 1.3rem;
+      }
+
+      .author-story-card__meta {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 0.75rem 1.5rem;
+        margin: 0;
+      }
+
+      .author-story-card__meta dt {
+        font-size: 0.75rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: rgba(148, 163, 184, 0.8);
+        margin-bottom: 0.15rem;
+      }
+
+      .author-story-card__meta dd {
+        margin: 0;
+        font-weight: 600;
+        color: #e2e8f0;
+      }
+
+      .author-story-card__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .author-story-card__actions .inline-form {
+        margin: 0;
+      }
+
+      .story-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.3rem 0.75rem;
+        border-radius: 999px;
+        font-size: 0.78rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        color: #e2e8f0;
+        background: rgba(148, 163, 184, 0.12);
+      }
+
+      .story-status-public {
+        background: rgba(34, 197, 94, 0.14);
+        border-color: rgba(34, 197, 94, 0.32);
+        color: #bbf7d0;
+      }
+
+      .story-status-pending,
+      .story-status-coming_soon {
+        background: rgba(59, 130, 246, 0.18);
+        border-color: rgba(59, 130, 246, 0.32);
+        color: #c7d2fe;
+      }
+
+      .story-status-under_review {
+        background: rgba(244, 114, 182, 0.18);
+        border-color: rgba(244, 114, 182, 0.32);
+        color: #fbcfe8;
+      }
+
+      .story-status-private {
+        background: rgba(148, 163, 184, 0.12);
+        border-color: rgba(148, 163, 184, 0.28);
+        color: #e2e8f0;
+      }
+
+      .empty-state {
+        padding: 2rem;
+        border-radius: 16px;
+        border: 1px dashed rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.6);
+        text-align: center;
+      }
+
+      .empty-state p {
+        margin: 0.25rem 0;
+      }
+
+      @media (max-width: 640px) {
+        .author-dashboard__intro {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .author-story-card__header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+      }
+    </style>
+  </body>
+</html>

--- a/views/user/authorDashboard.ejs
+++ b/views/user/authorDashboard.ejs
@@ -21,7 +21,9 @@
           Shadow Paths story builder. Submit drafts for review when you're ready
           to share them with the community.
         </p>
-        <a class="cta-button" href="/u/authors/stories/new">+ Create a new story</a>
+        <form action="/u/authors/stories/new" method="post">
+          <button type="submit" class="cta-button">+ Create a new story</button>
+        </form>
       </div>
 
       <% if (!stories || stories.length === 0) { %>
@@ -115,6 +117,10 @@
         border-radius: 16px;
         background: rgba(30, 41, 59, 0.55);
         border: 1px solid rgba(148, 163, 184, 0.18);
+      }
+
+      .author-dashboard__intro form {
+        margin: 0;
       }
 
       .author-dashboard__intro p {

--- a/views/user/authorDashboard.ejs
+++ b/views/user/authorDashboard.ejs
@@ -33,63 +33,86 @@
       </section>
       <% } else { %>
       <section class="author-stories">
-        <% stories.forEach(function (story) { %>
+        <% stories.forEach(function (story) { const coverSrc = story.coverImage || '/images/default-cover.svg'; %>
         <article class="author-story-card">
-          <header class="author-story-card__header">
-            <h2><%= story.title %></h2>
-            <span class="story-status story-status-<%= story.status %>">
-              <%= story.statusLabel %>
-            </span>
-          </header>
-          <dl class="author-story-card__meta">
-            <div>
-              <dt>Last updated</dt>
-              <dd><%= story.updatedAt ? new Date(story.updatedAt).toLocaleString() : '—' %></dd>
+          <div class="author-story-card__media">
+            <img
+              src="<%= coverSrc %>"
+              alt="Cover art for <%= story.title %>"
+              loading="lazy"
+            />
+          </div>
+          <div class="author-story-card__content">
+            <header class="author-story-card__header">
+              <div>
+                <h2><%= story.title %></h2>
+                <p class="author-story-card__status">
+                  <span class="story-status story-status-<%= story.status %>">
+                    <%= story.statusLabel %>
+                  </span>
+                </p>
+              </div>
+            </header>
+            <dl class="author-story-card__meta">
+              <div>
+                <dt>Last updated</dt>
+                <dd><%= story.updatedAt ? new Date(story.updatedAt).toLocaleString() : '—' %></dd>
+              </div>
+              <div>
+                <dt>Created</dt>
+                <dd><%= story.createdAt ? new Date(story.createdAt).toLocaleDateString() : '—' %></dd>
+              </div>
+              <% if (story.submittedAt) { %>
+              <div>
+                <dt>Submitted</dt>
+                <dd><%= new Date(story.submittedAt).toLocaleDateString() %></dd>
+              </div>
+              <% } %>
+              <% if (story.publishedAt) { %>
+              <div>
+                <dt>Published</dt>
+                <dd><%= new Date(story.publishedAt).toLocaleDateString() %></dd>
+              </div>
+              <% } %>
+            </dl>
+            <div class="author-story-card__actions">
+              <a class="cta-button small" href="/u/authors/stories/<%= story._id %>/edit"
+                >Edit draft</a
+              >
+              <a class="cta-button small ghost" href="/u/story/<%= story._id %>"
+                >Preview story</a
+              >
+              <% if (story.isPrivate) { %>
+              <form
+                method="post"
+                action="/u/authors/stories/<%= story._id %>/submit"
+                class="inline-form"
+              >
+                <button type="submit" class="cta-button small">Submit for review</button>
+              </form>
+              <% } %>
+              <% if (story.isPending || story.isUnderReview || story.isPublic) { %>
+              <form
+                method="post"
+                action="/u/authors/stories/<%= story._id %>/private"
+                class="inline-form"
+              >
+                <button type="submit" class="cta-button small ghost">
+                  Set to private
+                </button>
+              </form>
+              <% } %>
+              <% if (story.isPrivate) { %>
+              <form
+                method="post"
+                action="/u/authors/stories/<%= story._id %>/delete"
+                class="inline-form"
+                onsubmit="return confirm('Delete this story? This cannot be undone.');"
+              >
+                <button type="submit" class="cta-button small danger">Delete story</button>
+              </form>
+              <% } %>
             </div>
-            <div>
-              <dt>Created</dt>
-              <dd><%= story.createdAt ? new Date(story.createdAt).toLocaleDateString() : '—' %></dd>
-            </div>
-            <% if (story.submittedAt) { %>
-            <div>
-              <dt>Submitted</dt>
-              <dd><%= new Date(story.submittedAt).toLocaleDateString() %></dd>
-            </div>
-            <% } %>
-            <% if (story.publishedAt) { %>
-            <div>
-              <dt>Published</dt>
-              <dd><%= new Date(story.publishedAt).toLocaleDateString() %></dd>
-            </div>
-            <% } %>
-          </dl>
-          <div class="author-story-card__actions">
-            <a class="cta-button small" href="/u/authors/stories/<%= story._id %>/edit"
-              >Edit draft</a
-            >
-            <a class="cta-button small ghost" href="/u/story/<%= story._id %>"
-              >Preview story</a
-            >
-            <% if (story.isPrivate) { %>
-            <form
-              method="post"
-              action="/u/authors/stories/<%= story._id %>/submit"
-              class="inline-form"
-            >
-              <button type="submit" class="cta-button small">Submit for review</button>
-            </form>
-            <% } %>
-            <% if (story.isPending || story.isUnderReview || story.isPublic) { %>
-            <form
-              method="post"
-              action="/u/authors/stories/<%= story._id %>/private"
-              class="inline-form"
-            >
-              <button type="submit" class="cta-button small ghost">
-                Set to private
-              </button>
-            </form>
-            <% } %>
           </div>
         </article>
         <% }) %>
@@ -156,15 +179,38 @@
         background: rgba(17, 24, 39, 0.85);
         border: 1px solid rgba(148, 163, 184, 0.15);
         border-radius: 18px;
-        padding: 1.5rem;
+        padding: 1.25rem 1.5rem;
+        display: grid;
+        grid-template-columns: minmax(140px, 180px) 1fr;
+        gap: 1.5rem;
+        align-items: stretch;
+      }
+
+      .author-story-card__media {
+        border-radius: 14px;
+        overflow: hidden;
+        background: rgba(15, 23, 42, 0.8);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .author-story-card__media img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      .author-story-card__content {
         display: flex;
         flex-direction: column;
-        gap: 1.2rem;
+        gap: 1rem;
       }
 
       .author-story-card__header {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: space-between;
         gap: 1rem;
       }
@@ -172,6 +218,10 @@
       .author-story-card__header h2 {
         margin: 0;
         font-size: 1.3rem;
+      }
+
+      .author-story-card__status {
+        margin: 0.35rem 0 0;
       }
 
       .author-story-card__meta {
@@ -200,6 +250,16 @@
         flex-wrap: wrap;
         gap: 0.65rem;
         align-items: center;
+      }
+
+      .cta-button.danger {
+        background: rgba(239, 68, 68, 0.15);
+        border-color: rgba(248, 113, 113, 0.45);
+        color: #fecaca;
+      }
+
+      .cta-button.danger:hover {
+        background: rgba(239, 68, 68, 0.28);
       }
 
       .author-story-card__actions .inline-form {
@@ -263,9 +323,8 @@
           align-items: stretch;
         }
 
-        .author-story-card__header {
-          flex-direction: column;
-          align-items: flex-start;
+        .author-story-card {
+          grid-template-columns: 1fr;
         }
       }
     </style>

--- a/views/user/authorImages.ejs
+++ b/views/user/authorImages.ejs
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <%- include('../partials/head') %>
+  </head>
+  <body class="author-images-body">
+    <%- include('../partials/header', { user }) %>
+
+    <main class="container author-images">
+      <div class="back-link">
+        <a href="/u/authors/stories/<%= story._id %>/edit" class="cta-button small"
+          >← Back to Story Builder</a
+        >
+      </div>
+
+      <header class="author-images__header">
+        <div>
+          <h1 class="title">Image Library</h1>
+          <p class="subtitle">Uploads for <strong><%= story.title || 'Untitled Story' %></strong></p>
+        </div>
+      </header>
+
+      <% if (flash && flash.message) { %>
+      <div class="flash flash-<%= flash.type === 'error' ? 'error' : 'success' %>">
+        <%= flash.message %>
+      </div>
+      <% } %>
+
+      <section class="panel upload-panel">
+        <form
+          action="/u/authors/stories/<%= story._id %>/images/upload"
+          method="post"
+          enctype="multipart/form-data"
+          class="upload-form"
+        >
+          <label class="field">
+            <span>Upload a new image</span>
+            <input type="file" name="image" accept="image/*" required />
+          </label>
+          <p class="upload-hint">
+            Images are optimized automatically. Supported formats: JPG, PNG, GIF, WEBP. Max size 5MB.
+          </p>
+          <button type="submit" class="cta-button">Upload Image</button>
+        </form>
+      </section>
+
+      <section class="panel gallery-panel">
+        <h2>Your Images</h2>
+        <% if (!images || images.length === 0) { %>
+        <p class="muted">No images uploaded yet. Add one above to start building your visual library.</p>
+        <% } else { %>
+        <ul class="image-grid">
+          <% images.forEach(function (img) { const src = img.url; const title = img.title || ''; const pid = img.publicId || ''; %>
+          <li class="image-card">
+            <div class="image-frame">
+              <img src="<%= src %>" alt="Story artwork" />
+            </div>
+            <div class="image-meta">
+              <span class="meta-label">File name</span>
+              <span class="meta-value"><%= title || src %></span>
+            </div>
+            <form
+              action="/u/authors/stories/<%= story._id %>/images/delete"
+              method="post"
+              class="image-actions"
+              onsubmit="return confirm('Remove this image from your library?');"
+            >
+              <input type="hidden" name="url" value="<%= src %>" />
+              <input type="hidden" name="publicId" value="<%= pid %>" />
+              <button type="submit" class="btn danger small">Delete</button>
+            </form>
+          </li>
+          <% }) %>
+        </ul>
+        <% } %>
+      </section>
+    </main>
+
+    <style>
+      .author-images-body {
+        background: radial-gradient(circle at top, rgba(30, 41, 59, 0.35), #05060b);
+        color: #e2e8f0;
+      }
+
+      .author-images {
+        padding: 3rem 0 4rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+
+      .author-images .panel {
+        background: rgba(15, 23, 42, 0.78);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 16px;
+        padding: 1.5rem;
+      }
+
+      .author-images__header .title {
+        margin: 0;
+        font-size: 1.6rem;
+      }
+
+      .author-images__header .subtitle {
+        margin: 0.35rem 0 0;
+        color: #94a3b8;
+        font-size: 0.95rem;
+      }
+
+      .flash {
+        padding: 0.9rem 1.1rem;
+        border-radius: 12px;
+        font-weight: 600;
+      }
+
+      .flash-success {
+        background: rgba(34, 197, 94, 0.12);
+        border: 1px solid rgba(34, 197, 94, 0.28);
+        color: #bbf7d0;
+      }
+
+      .flash-error {
+        background: rgba(248, 113, 113, 0.12);
+        border: 1px solid rgba(248, 113, 113, 0.28);
+        color: #fecaca;
+      }
+
+      .upload-form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .upload-form .field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+
+      .upload-form .field span {
+        font-size: 0.9rem;
+        color: #cbd5f5;
+      }
+
+      .upload-form input[type="file"] {
+        border: 1px dashed rgba(148, 163, 184, 0.4);
+        padding: 0.75rem;
+        border-radius: 12px;
+        background: rgba(30, 41, 59, 0.55);
+        color: inherit;
+      }
+
+      .upload-hint {
+        margin: 0;
+        font-size: 0.8rem;
+        color: #94a3b8;
+      }
+
+      .gallery-panel h2 {
+        margin: 0 0 1rem;
+        font-size: 1.1rem;
+        color: #cbd5f5;
+      }
+
+      .muted {
+        color: #94a3b8;
+      }
+
+      .image-grid {
+        list-style: none;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1.25rem;
+        padding: 0;
+        margin: 0;
+      }
+
+      .image-card {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        background: rgba(11, 16, 26, 0.78);
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: 14px;
+        padding: 1rem;
+      }
+
+      .image-frame {
+        border-radius: 12px;
+        overflow: hidden;
+        background: rgba(148, 163, 184, 0.12);
+      }
+
+      .image-card img {
+        display: block;
+        width: 100%;
+        height: auto;
+      }
+
+      .image-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 0.3rem;
+        font-size: 0.85rem;
+      }
+
+      .meta-label {
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #64748b;
+        font-size: 0.72rem;
+      }
+
+      .meta-value {
+        font-family: "JetBrains Mono", monospace;
+        background: rgba(15, 23, 42, 0.75);
+        padding: 0.4rem 0.5rem;
+        border-radius: 8px;
+        word-break: break-all;
+      }
+
+      .image-actions {
+        display: flex;
+        justify-content: flex-end;
+      }
+
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 999px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(30, 41, 59, 0.65);
+        color: #e2e8f0;
+        font-weight: 600;
+        padding: 0.45rem 1rem;
+        cursor: pointer;
+        transition: background 0.2s ease, border-color 0.2s ease;
+      }
+
+      .btn.small {
+        padding: 0.35rem 0.85rem;
+        font-size: 0.82rem;
+      }
+
+      .btn:hover {
+        background: rgba(148, 163, 184, 0.22);
+        border-color: rgba(148, 163, 184, 0.45);
+      }
+
+      .btn.danger {
+        background: rgba(239, 68, 68, 0.18);
+        border-color: rgba(239, 68, 68, 0.32);
+        color: #fecaca;
+      }
+
+      .btn.danger:hover {
+        background: rgba(239, 68, 68, 0.28);
+      }
+
+      .cta-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.55rem 1.15rem;
+        border-radius: 999px;
+        border: none;
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        color: #fff;
+        font-weight: 600;
+        text-decoration: none;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+
+      .cta-button.small {
+        padding: 0.45rem 1rem;
+        font-size: 0.85rem;
+      }
+
+      .cta-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 24px rgba(99, 102, 241, 0.25);
+      }
+    </style>
+
+    <%- include('../partials/footer') %>
+  </body>
+</html>

--- a/views/user/authorImages.ejs
+++ b/views/user/authorImages.ejs
@@ -78,7 +78,7 @@
 
     <style>
       .author-images-body {
-        background: radial-gradient(circle at top, rgba(30, 41, 59, 0.35), #05060b);
+        background: #05060b;
         color: #e2e8f0;
       }
 

--- a/views/user/library.ejs
+++ b/views/user/library.ejs
@@ -171,7 +171,8 @@
           <%= trophyPopups[0].message %>
         </div>
         <div class="trophy-coins" id="trophy-modal-coins">
-          +<%= trophyPopups[0].amount %> coins
+          +<%= trophyPopups[0].amount %>
+          <%= trophyPopups[0].currencyLabel || 'coins' %>
         </div>
 
         <div class="trophy-actions">
@@ -211,7 +212,8 @@
             const item = queue[i];
             if (!item) { return closeModal(); }
             message.textContent = item.message || 'Achievement unlocked!';
-            coinsEl.textContent = `+${Number(item.amount || 0)} coins`;
+            const label = item.currencyLabel || 'coins';
+            coinsEl.textContent = `+${Number(item.amount || 0)} ${label}`;
             btn.textContent = (i < queue.length - 1) ? 'Next' : 'Got it';
             overlay.classList.remove('hide');
             modal.classList.remove('hide');

--- a/views/user/library.ejs
+++ b/views/user/library.ejs
@@ -7,11 +7,26 @@
     <%- include('../partials/header', { user }) %>
 
     <main class="container library">
-      <h1 class="title">Story Library</h1>
+      <% const currentLibraryType = typeof libraryType === 'string' ? libraryType : 'official'; %>
+      <% const heading = currentLibraryType === 'user' ? 'User Created Stories' : 'Story Library'; %>
+      <h1 class="title"><%= heading %></h1>
       <p class="muted">
+        <% if (currentLibraryType === 'user') { %>
+        Discover community-created adventures. Pending stories are marked as
+        coming soon while they await approval.
+        <% } else { %>
         Browse the adventures you can begin. Your choices will shape the endings
         you find.
+        <% } %>
       </p>
+
+      <% if (Array.isArray(libraryLinks) && libraryLinks.length) { %>
+      <div class="library-nav-links">
+        <% libraryLinks.forEach(function (link) { %>
+        <a class="cta-button ghost" href="<%= link.href %>"><%= link.label %></a>
+        <% }) %>
+      </div>
+      <% } %>
 
       <% const hasStories = Array.isArray(stories) && stories.length > 0; %>
 
@@ -96,6 +111,9 @@
             <% const showProgress = Number(story.totalEndings) > 0; %>
             <% if (hasCategories || showProgress) { %>
             <div class="story-card__meta">
+              <% if (currentLibraryType === 'user' && story.authorName) { %>
+              <p class="story-card__author">By <%= story.authorName %></p>
+              <% } %>
               <% if (hasCategories) { %>
               <ul class="tag-list">
                 <% story.categories.forEach(function(cat) { %>
@@ -114,10 +132,12 @@
             <% } %>
 
             <div class="story-card__actions">
-              <% if (story.status === "public") { %>
+              <% if (story.actionType === 'play') { %>
               <a href="/u/story/<%= story._id %>" class="cta-button">Play</a>
               <% } else { %>
-              <span class="coming-soon">Coming Soon</span>
+              <span class="story-status story-status-<%= story.status %>">
+                <%= story.actionLabel %>
+              </span>
               <% } %>
             </div>
           </div>

--- a/views/user/playNode.ejs
+++ b/views/user/playNode.ejs
@@ -7,6 +7,11 @@
     <%- include('../partials/header', { user }) %>
 
     <main class="container">
+      <% const meta = currencyMeta || {}; %>
+      <% const currencyIconClass = meta.iconClass || 'icon-gem'; %>
+      <% const currencyLabelText = meta.label || 'Your gems'; %>
+      <% const currencyPlural = meta.plural || 'gems'; %>
+      <% const currencySingular = meta.singular || 'gem'; %>
       <h2><%= story.title %></h2>
 
       <% if (node.image) { %>
@@ -41,7 +46,7 @@
             type="submit"
             class="cta-button choice-button locked"
             <%= disabled ? 'disabled' : '' %>
-            aria-label="Unlock &ldquo;<%= c.label %>&rdquo; for <%= c.unlockCost %> gems"
+            aria-label="Unlock &ldquo;<%= c.label %>&rdquo; for <%= c.unlockCost %> <%= c.unlockCost === 1 ? currencySingular.toLowerCase() : currencyPlural.toLowerCase() %>"
           >
             <span class="choice-main">
               <span class="choice-icon" aria-hidden="true">
@@ -55,7 +60,7 @@
               <span class="choice-label"><%= c.label %></span>
             </span>
             <span class="choice-cost">
-              <span class="icon icon-gem" aria-hidden="true">
+              <span class="icon <%= currencyIconClass %>" aria-hidden="true">
                 <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                   <path
                     fill="currentColor"
@@ -67,7 +72,10 @@
             </span>
           </button>
           <% if (disabled && c.unlockCost > 0) { %>
-          <p class="unlock-hint">You need <%= remaining %> more gems.</p>
+          <p class="unlock-hint">
+            You need <%= remaining %> more
+            <%= remaining === 1 ? currencySingular.toLowerCase() : currencyPlural.toLowerCase() %>.
+          </p>
           <% } %>
         </form>
 
@@ -92,7 +100,7 @@
           </span>
           <% if (c.isLocked && c.unlockCost > 0) { %>
           <span class="choice-cost">
-            <span class="icon icon-gem" aria-hidden="true">
+            <span class="icon <%= currencyIconClass %>" aria-hidden="true">
               <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                 <path
                   fill="currentColor"
@@ -110,7 +118,7 @@
 
       <% if (hasLockedChoices) { %>
       <div class="currency-readout" aria-live="polite">
-        <span class="icon icon-gem" aria-hidden="true">
+        <span class="icon <%= currencyIconClass %>" aria-hidden="true">
           <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path
               fill="currentColor"
@@ -119,7 +127,7 @@
           </svg>
         </span>
         <div class="currency-readout__content">
-          <span class="currency-readout__label">Your gems</span>
+          <span class="currency-readout__label"><%= currencyLabelText %></span>
           <strong class="currency-readout__value"><%= currency || 0 %></strong>
         </div>
       </div>

--- a/views/user/stats.ejs
+++ b/views/user/stats.ejs
@@ -73,6 +73,24 @@
             <span class="overview-caption">Create more tales from the Authors tab.</span>
           </article>
           <article class="overview-card">
+            <span class="overview-label">Community stories started</span>
+            <span class="overview-value">
+              <%= typeof statsOverview.communityStoriesStarted === "number"
+                ? statsOverview.communityStoriesStarted
+                : 0 %>
+            </span>
+            <span class="overview-caption">Discover adventures crafted by other authors.</span>
+          </article>
+          <article class="overview-card">
+            <span class="overview-label">Stories published</span>
+            <span class="overview-value">
+              <%= typeof statsOverview.publishedStories === "number"
+                ? statsOverview.publishedStories
+                : 0 %>
+            </span>
+            <span class="overview-caption">Share your worlds with the community.</span>
+          </article>
+          <article class="overview-card">
             <span class="overview-label">True endings found</span>
             <span class="overview-value"><%= typeof statsOverview.trueEndingsFound === "number" ? statsOverview.trueEndingsFound : 0 %></span>
           </article>

--- a/views/user/stats.ejs
+++ b/views/user/stats.ejs
@@ -33,8 +33,23 @@
             <span class="value"><%= typeof safeUser.currency === "number" ? safeUser.currency : 0 %></span>
           </div>
         </div>
+        <div class="stats-hero__gems stats-hero__gems--author" aria-live="polite">
+          <span class="icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                fill="currentColor"
+                d="M12 2 3 9l9 13 9-13-9-7zm4.5 5.5L12 5.2 7.5 7.5 6 10l6 9 6-9z"
+              />
+            </svg>
+          </span>
+          <div class="stats-hero__gems-info">
+            <span class="label">Your author gems</span>
+            <span class="value"><%= typeof safeUser.authorCurrency === "number" ? safeUser.authorCurrency : 0 %></span>
+          </div>
+        </div>
         <p class="stats-hero__hint">
-          Earn more gems by finding endings and earning trophies.
+          Earn more gems by finding endings and trophies. Author gems unlock
+          special paths inside community-created stories.
         </p>
       </section>
 
@@ -55,7 +70,7 @@
           <article class="overview-card">
             <span class="overview-label">Stories created</span>
             <span class="overview-value"><%= typeof statsOverview.storiesCreated === "number" ? statsOverview.storiesCreated : 0 %></span>
-            <span class="overview-caption">Tracking coming soon</span>
+            <span class="overview-caption">Create more tales from the Authors tab.</span>
           </article>
           <article class="overview-card">
             <span class="overview-label">True endings found</span>

--- a/views/user/storyBuilder.ejs
+++ b/views/user/storyBuilder.ejs
@@ -49,7 +49,6 @@
         action="<%= builderMode === 'edit' ? `/u/authors/stories/${storyId}` : '/u/authors/stories' %>"
       >
         <section class="panel story-details-panel">
-          <h2>Story Details</h2>
           <div class="story-details-grid">
             <label class="field">
               <span>Title</span>
@@ -71,14 +70,6 @@
                 Upload images once your draft is created.
                 <% } %>
               </span>
-            </label>
-            <label class="field">
-              <span>Author Notes (private)</span>
-              <textarea
-                name="notes"
-                rows="4"
-                placeholder="Keep track of reminders or drafting notes"
-              ><%= formData.notes || '' %></textarea>
             </label>
             <label class="field field--wide field--multiline">
               <span>Description (public)</span>
@@ -112,8 +103,8 @@
         <section class="map-panel">
           <div class="map-controls">
             <p>
-              Drag passages into place, select a node to edit it, and add choices to
-              build your branching story.
+              Drag passages into place. Double-click a node or ending to open its
+              editor.
             </p>
             <div class="map-controls-right">
               <div class="map-zoom-controls" role="group" aria-label="Zoom map view">
@@ -187,10 +178,6 @@
             <span>Story Text</span>
             <textarea name="text" rows="10" class="monospace"></textarea>
           </label>
-          <label class="field field--multiline">
-            <span>Author Notes</span>
-            <textarea name="notes" rows="5" placeholder="Optional notes just for you"></textarea>
-          </label>
           <div class="form-actions">
             <button type="submit" class="btn small">Save Passage</button>
           </div>
@@ -201,10 +188,6 @@
           <div id="choice-list"></div>
           <form id="choice-add-form" class="choice-form">
             <div class="choice-fields">
-              <label class="choice-field">
-                <span>Choice ID (optional)</span>
-                <input type="text" name="_id" placeholder="auto-generated" />
-              </label>
               <label class="choice-field choice-field--label">
                 <span>Label</span>
                 <input type="text" name="label" placeholder="Choice label" required />
@@ -254,10 +237,6 @@
             <span>Ending Text</span>
             <textarea name="text" rows="10" class="monospace"></textarea>
           </label>
-          <label class="field field--multiline">
-            <span>Author Notes</span>
-            <textarea name="notes" rows="5" placeholder="Optional notes"></textarea>
-          </label>
           <div class="form-actions">
             <button type="submit" class="btn small">Save Ending</button>
           </div>
@@ -270,7 +249,6 @@
     <script id="builder-data" type="application/json"><%- JSON.stringify({
       title: formData.title || '',
       description: formData.description || '',
-      notes: formData.notes || '',
       coverImage: formData.coverImage || '',
       categories: formData.categories || [],
       startNodeId: formData.startNodeId || '',

--- a/views/user/storyBuilder.ejs
+++ b/views/user/storyBuilder.ejs
@@ -1,0 +1,656 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <%- include('../partials/head') %>
+  </head>
+  <body>
+    <%- include('../partials/header', { user }) %>
+
+    <main class="container story-builder">
+      <h1 class="title">
+        <%= builderMode === 'edit' ? 'Edit Story' : 'Create a New Story' %>
+      </h1>
+
+      <% if (storyStatus && builderMode === 'edit') { %>
+      <div class="story-status story-status-<%= storyStatus %>">
+        Current status: <strong><%= storyStatus %></strong>
+      </div>
+      <% } %>
+
+      <% if (errors && errors.length) { %>
+      <div class="flash flash-error">
+        <p>We found a few issues with your story:</p>
+        <ul>
+          <% errors.forEach(function(err) { %>
+          <li><%= err %></li>
+          <% }) %>
+        </ul>
+      </div>
+      <% } %>
+
+      <form
+        id="authorStoryForm"
+        class="builder-form"
+        method="post"
+        action="<%= builderMode === 'edit' ? `/u/authors/stories/${storyId}` : '/u/authors/stories' %>"
+      >
+        <section class="builder-panel">
+          <h2>Story details</h2>
+          <div class="builder-grid">
+            <label>
+              <span>Title</span>
+              <input
+                type="text"
+                name="title"
+                value="<%= formData.title || '' %>"
+                required
+              />
+            </label>
+            <label>
+              <span>Start node</span>
+              <select name="startNodeId" id="startNodeId">
+                <option value="">Select after adding nodes</option>
+              </select>
+            </label>
+          </div>
+
+          <label>
+            <span>Description</span>
+            <textarea
+              name="description"
+              rows="3"
+              placeholder="A quick overview for readers"
+            ><%= formData.description || '' %></textarea>
+          </label>
+
+          <label>
+            <span>Cover image URL</span>
+            <input
+              type="text"
+              name="coverImage"
+              value="<%= formData.coverImage || '' %>"
+              placeholder="https://example.com/cover.jpg"
+            />
+          </label>
+
+          <label>
+            <span>Author notes (optional)</span>
+            <textarea
+              name="notes"
+              rows="3"
+              placeholder="Keep track of ideas or drafting notes"
+            ><%= formData.notes || '' %></textarea>
+          </label>
+
+          <% if (Array.isArray(availableCategories) && availableCategories.length) { %>
+          <fieldset class="category-fieldset">
+            <legend>Categories</legend>
+            <div class="category-grid">
+              <% availableCategories.forEach(function (cat) { %>
+              <label class="category-option">
+                <input
+                  type="checkbox"
+                  name="categories"
+                  value="<%= cat %>"
+                  <%= Array.isArray(formData.categories) && formData.categories.includes(cat) ? 'checked' : '' %>
+                />
+                <span><%= cat %></span>
+              </label>
+              <% }) %>
+            </div>
+          </fieldset>
+          <% } %>
+        </section>
+
+        <section class="builder-panel">
+          <header class="panel-header">
+            <h2>Passages</h2>
+            <button type="button" class="cta-button small" id="addNodeBtn">
+              + Add passage
+            </button>
+          </header>
+          <p class="muted">
+            Each passage needs a unique ID. Choices link to other passages or
+            endings using those IDs.
+          </p>
+          <div id="nodesContainer" class="builder-stack"></div>
+        </section>
+
+        <section class="builder-panel">
+          <header class="panel-header">
+            <h2>Endings</h2>
+            <button type="button" class="cta-button small" id="addEndingBtn">
+              + Add ending
+            </button>
+          </header>
+          <div id="endingsContainer" class="builder-stack"></div>
+        </section>
+
+        <div class="builder-actions">
+          <button type="submit" class="cta-button">
+            <%= builderMode === 'edit' ? 'Save changes' : 'Save draft' %>
+          </button>
+          <p class="muted">
+            Submit your story for review from the Author Library when you're
+            ready to share it.
+          </p>
+        </div>
+      </form>
+    </main>
+
+    <%- include('../partials/footer') %>
+
+    <template id="nodeTemplate">
+      <div class="builder-card" data-node>
+        <div class="builder-card__header">
+          <h3>Passage</h3>
+          <button type="button" class="link remove-node">Remove</button>
+        </div>
+        <div class="builder-grid">
+          <label>
+            <span>Node ID</span>
+            <input type="text" data-field="_id" required />
+          </label>
+          <label>
+            <span>Display color</span>
+            <input type="text" data-field="color" placeholder="twilight" />
+          </label>
+        </div>
+        <label>
+          <span>Passage text</span>
+          <textarea data-field="text" rows="4" required></textarea>
+        </label>
+        <label>
+          <span>Image URL</span>
+          <input type="text" data-field="image" />
+        </label>
+        <label>
+          <span>Notes</span>
+          <textarea data-field="notes" rows="2"></textarea>
+        </label>
+        <div class="choice-list" data-choices></div>
+        <button type="button" class="link add-choice">+ Add choice</button>
+      </div>
+    </template>
+
+    <template id="choiceTemplate">
+      <div class="choice-card" data-choice>
+        <div class="builder-grid">
+          <label>
+            <span>Choice label</span>
+            <input type="text" data-choice-field="label" required />
+          </label>
+          <label>
+            <span>Leads to (node or ending ID)</span>
+            <input type="text" data-choice-field="nextNodeId" required />
+          </label>
+        </div>
+        <div class="choice-options">
+          <label class="choice-lock">
+            <input type="checkbox" data-choice-field="locked" />
+            Locked choice
+          </label>
+          <label class="choice-cost">
+            <span>Unlock cost</span>
+            <input type="number" min="0" data-choice-field="unlockCost" value="0" />
+          </label>
+        </div>
+        <button type="button" class="link remove-choice">Remove choice</button>
+        <input type="hidden" data-choice-field="_id" />
+      </div>
+    </template>
+
+    <template id="endingTemplate">
+      <div class="builder-card" data-ending>
+        <div class="builder-card__header">
+          <h3>Ending</h3>
+          <button type="button" class="link remove-ending">Remove</button>
+        </div>
+        <div class="builder-grid">
+          <label>
+            <span>Ending ID</span>
+            <input type="text" data-ending-field="_id" required />
+          </label>
+          <label>
+            <span>Label</span>
+            <input type="text" data-ending-field="label" required />
+          </label>
+          <label>
+            <span>Type</span>
+            <select data-ending-field="type">
+              <option value="true">True</option>
+              <option value="death">Death</option>
+              <option value="secret">Secret</option>
+              <option value="other" selected>Other</option>
+            </select>
+          </label>
+        </div>
+        <label>
+          <span>Ending text</span>
+          <textarea data-ending-field="text" rows="3"></textarea>
+        </label>
+        <label>
+          <span>Notes</span>
+          <textarea data-ending-field="notes" rows="2"></textarea>
+        </label>
+      </div>
+    </template>
+
+    <script>
+      window.initialStoryData = <%- JSON.stringify(formData || {}) %>;
+    </script>
+    <script>
+      (function () {
+        const data = window.initialStoryData || {};
+        const nodesContainer = document.getElementById('nodesContainer');
+        const endingsContainer = document.getElementById('endingsContainer');
+        const addNodeBtn = document.getElementById('addNodeBtn');
+        const addEndingBtn = document.getElementById('addEndingBtn');
+        const nodeTemplate = document.getElementById('nodeTemplate');
+        const choiceTemplate = document.getElementById('choiceTemplate');
+        const endingTemplate = document.getElementById('endingTemplate');
+        const startNodeSelect = document.getElementById('startNodeId');
+
+        function updateStartNodeOptions() {
+          const current = startNodeSelect.value;
+          startNodeSelect.innerHTML = '';
+          const placeholder = document.createElement('option');
+          placeholder.value = '';
+          placeholder.textContent = 'Select after adding nodes';
+          startNodeSelect.appendChild(placeholder);
+
+          const nodeIds = [];
+          nodesContainer.querySelectorAll('[data-node]').forEach((nodeEl) => {
+            const idInput = nodeEl.querySelector('[data-field="_id"]');
+            if (idInput && idInput.value.trim()) {
+              nodeIds.push(idInput.value.trim());
+            }
+          });
+
+          nodeIds.forEach((id) => {
+            const option = document.createElement('option');
+            option.value = id;
+            option.textContent = id;
+            if (id === current) {
+              option.selected = true;
+            }
+            startNodeSelect.appendChild(option);
+          });
+
+          if (!startNodeSelect.value && nodeIds.length > 0) {
+            startNodeSelect.value = nodeIds[0];
+          }
+        }
+
+        function syncNodeNames() {
+          nodesContainer.querySelectorAll('[data-node]').forEach((nodeEl, nodeIndex) => {
+            nodeEl.querySelectorAll('[data-field]').forEach((input) => {
+              const field = input.dataset.field;
+              input.name = `nodes[${nodeIndex}][${field}]`;
+            });
+
+            nodeEl.querySelectorAll('[data-choice]').forEach((choiceEl, choiceIndex) => {
+              choiceEl.querySelectorAll('[data-choice-field]').forEach((input) => {
+                const field = input.dataset.choiceField;
+                input.name = `nodes[${nodeIndex}][choices][${choiceIndex}][${field}]`;
+              });
+
+              const lockCheckbox = choiceEl.querySelector('[data-choice-field="locked"]');
+              const costField = choiceEl.querySelector('[data-choice-field="unlockCost"]');
+              if (costField) {
+                costField.disabled = !(lockCheckbox && lockCheckbox.checked);
+              }
+            });
+          });
+
+          updateStartNodeOptions();
+        }
+
+        function syncEndingNames() {
+          endingsContainer.querySelectorAll('[data-ending]').forEach((endingEl, endingIndex) => {
+            endingEl.querySelectorAll('[data-ending-field]').forEach((input) => {
+              const field = input.dataset.endingField;
+              input.name = `endings[${endingIndex}][${field}]`;
+            });
+          });
+        }
+
+        function createChoice(choice = {}) {
+          const clone = choiceTemplate.content.firstElementChild.cloneNode(true);
+          clone.querySelectorAll('[data-choice-field]').forEach((input) => {
+            const field = input.dataset.choiceField;
+            if (field === '_id' && choice._id) {
+              input.value = choice._id;
+            }
+            if (field === 'label') input.value = choice.label || '';
+            if (field === 'nextNodeId') input.value = choice.nextNodeId || '';
+            if (field === 'locked') input.checked = Boolean(choice.locked);
+            if (field === 'unlockCost') input.value = Number(choice.unlockCost || 0);
+          });
+          clone.querySelector('.remove-choice').addEventListener('click', () => {
+            clone.remove();
+            syncNodeNames();
+          });
+          const lockCheckbox = clone.querySelector('[data-choice-field="locked"]');
+          const costField = clone.querySelector('[data-choice-field="unlockCost"]');
+          if (lockCheckbox && costField) {
+            lockCheckbox.addEventListener('change', () => {
+              costField.disabled = !lockCheckbox.checked;
+              if (!lockCheckbox.checked) {
+                costField.value = 0;
+              }
+            });
+            costField.disabled = !lockCheckbox.checked;
+          }
+          return clone;
+        }
+
+        function createNode(node = {}) {
+          const clone = nodeTemplate.content.firstElementChild.cloneNode(true);
+          clone.querySelectorAll('[data-field]').forEach((input) => {
+            const field = input.dataset.field;
+            if (field === '_id') input.value = node._id || '';
+            if (field === 'text') input.value = node.text || '';
+            if (field === 'image') input.value = node.image || '';
+            if (field === 'notes') input.value = node.notes || '';
+            if (field === 'color') input.value = node.color || '';
+          });
+
+          const choicesContainer = clone.querySelector('[data-choices]');
+          const nodeChoices = Array.isArray(node.choices) ? node.choices : [];
+          if (nodeChoices.length === 0) {
+            choicesContainer.appendChild(createChoice());
+          } else {
+            nodeChoices.forEach((choice) => {
+              choicesContainer.appendChild(createChoice(choice));
+            });
+          }
+
+          clone.querySelector('.add-choice').addEventListener('click', () => {
+            choicesContainer.appendChild(createChoice());
+            syncNodeNames();
+          });
+
+          clone.querySelector('.remove-node').addEventListener('click', () => {
+            clone.remove();
+            syncNodeNames();
+          });
+
+          return clone;
+        }
+
+        function createEnding(ending = {}) {
+          const clone = endingTemplate.content.firstElementChild.cloneNode(true);
+          clone.querySelectorAll('[data-ending-field]').forEach((input) => {
+            const field = input.dataset.endingField;
+            if (field === '_id') input.value = ending._id || '';
+            if (field === 'label') input.value = ending.label || '';
+            if (field === 'type') input.value = ending.type || 'other';
+            if (field === 'text') input.value = ending.text || '';
+            if (field === 'notes') input.value = ending.notes || '';
+          });
+          clone.querySelector('.remove-ending').addEventListener('click', () => {
+            clone.remove();
+            syncEndingNames();
+          });
+          return clone;
+        }
+
+        addNodeBtn.addEventListener('click', () => {
+          nodesContainer.appendChild(createNode());
+          syncNodeNames();
+        });
+
+        addEndingBtn.addEventListener('click', () => {
+          endingsContainer.appendChild(createEnding());
+          syncEndingNames();
+        });
+
+        const initialNodes = Array.isArray(data.nodes) ? data.nodes : [];
+        if (initialNodes.length === 0) {
+          nodesContainer.appendChild(createNode());
+        } else {
+          initialNodes.forEach((node) => {
+            nodesContainer.appendChild(createNode(node));
+          });
+        }
+
+        const initialEndings = Array.isArray(data.endings) ? data.endings : [];
+        if (initialEndings.length === 0) {
+          endingsContainer.appendChild(createEnding());
+        } else {
+          initialEndings.forEach((ending) => {
+            endingsContainer.appendChild(createEnding(ending));
+          });
+        }
+
+        syncNodeNames();
+        syncEndingNames();
+
+        if (data.startNodeId) {
+          startNodeSelect.value = data.startNodeId;
+        }
+      })();
+    </script>
+
+    <style>
+      .story-builder {
+        padding-bottom: 4rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.75rem;
+      }
+
+      .builder-form {
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+      }
+
+      .builder-panel {
+        padding: 1.75rem;
+        border-radius: 18px;
+        background: rgba(17, 24, 39, 0.85);
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+      }
+
+      .panel-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .builder-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+      }
+
+      .builder-grid label,
+      .builder-panel label,
+      .builder-panel textarea,
+      .builder-panel input {
+        width: 100%;
+      }
+
+      label span,
+      legend {
+        font-size: 0.85rem;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: rgba(148, 163, 184, 0.85);
+        display: block;
+        margin-bottom: 0.35rem;
+      }
+
+      input[type='text'],
+      input[type='number'],
+      select,
+      textarea {
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        background: rgba(15, 23, 42, 0.85);
+        color: #e2e8f0;
+        padding: 0.65rem 0.8rem;
+        font-size: 0.95rem;
+      }
+
+      textarea {
+        min-height: 120px;
+      }
+
+      .builder-stack {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .builder-card {
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        background: rgba(30, 41, 59, 0.6);
+        border-radius: 16px;
+        padding: 1.25rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .builder-card__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      .builder-card__header h3 {
+        margin: 0;
+        font-size: 1.1rem;
+      }
+
+      .choice-card {
+        border: 1px dashed rgba(148, 163, 184, 0.35);
+        border-radius: 14px;
+        padding: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        background: rgba(15, 23, 42, 0.55);
+      }
+
+      .choice-options {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .choice-lock {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.9rem;
+      }
+
+      .choice-cost {
+        flex: 1 1 120px;
+      }
+
+      .choice-cost input {
+        width: 100%;
+      }
+
+      .category-fieldset {
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        border-radius: 14px;
+        padding: 1rem 1.25rem;
+      }
+
+      .category-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 0.5rem 1rem;
+      }
+
+      .category-option {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        font-size: 0.9rem;
+      }
+
+      .builder-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        align-items: flex-start;
+      }
+
+      .flash {
+        padding: 1rem 1.25rem;
+        border-radius: 14px;
+      }
+
+      .flash-error {
+        border: 1px solid rgba(248, 113, 113, 0.35);
+        background: rgba(248, 113, 113, 0.12);
+        color: #fecaca;
+      }
+
+      .link {
+        background: none;
+        border: none;
+        color: #93c5fd;
+        cursor: pointer;
+        font-size: 0.9rem;
+        text-decoration: underline;
+      }
+
+      .story-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.35rem 0.85rem;
+        border-radius: 999px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        color: #e2e8f0;
+        background: rgba(148, 163, 184, 0.12);
+        width: fit-content;
+      }
+
+      .story-status-public {
+        background: rgba(34, 197, 94, 0.18);
+        border-color: rgba(34, 197, 94, 0.32);
+        color: #bbf7d0;
+      }
+
+      .story-status-pending,
+      .story-status-coming_soon {
+        background: rgba(59, 130, 246, 0.18);
+        border-color: rgba(59, 130, 246, 0.32);
+        color: #c7d2fe;
+      }
+
+      .story-status-under_review {
+        background: rgba(244, 114, 182, 0.18);
+        border-color: rgba(244, 114, 182, 0.32);
+        color: #fbcfe8;
+      }
+
+      @media (max-width: 720px) {
+        .builder-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .choice-options {
+          flex-direction: column;
+          align-items: stretch;
+        }
+      }
+    </style>
+  </body>
+</html>

--- a/views/user/storyBuilder.ejs
+++ b/views/user/storyBuilder.ejs
@@ -2,92 +2,94 @@
 <html lang="en">
   <head>
     <%- include('../partials/head') %>
+    <link rel="stylesheet" href="/css/authorBuilder.css" />
+    <script src="https://cdn.jsdelivr.net/npm/interactjs@1.10.17/dist/interact.min.js"></script>
   </head>
   <body>
     <%- include('../partials/header', { user }) %>
 
-    <main class="container story-builder">
-      <h1 class="title">
-        <%= builderMode === 'edit' ? 'Edit Story' : 'Create a New Story' %>
-      </h1>
-
-      <% if (storyStatus && builderMode === 'edit') { %>
-      <div class="story-status story-status-<%= storyStatus %>">
-        Current status: <strong><%= storyStatus %></strong>
-      </div>
-      <% } %>
+    <main class="story-editor-shell">
+      <section class="panel editor-toolbar">
+        <div class="toolbar-heading">
+          <h1>
+            <%= builderMode === 'edit' ? 'Edit Story' : 'Create a New Story' %>
+          </h1>
+          <% if (storyStatus) { %>
+          <span class="story-status story-status-<%= storyStatus %>">
+            Status: <strong><%= storyStatus %></strong>
+          </span>
+          <% } %>
+        </div>
+        <div class="toolbar-group">
+          <a href="/u/authors" class="btn ghost">Back to Author Library</a>
+          <button type="submit" form="authorStoryForm" class="btn primary">
+            <%= builderMode === 'edit' ? 'Save Changes' : 'Save Draft' %>
+          </button>
+        </div>
+      </section>
 
       <% if (errors && errors.length) { %>
-      <div class="flash flash-error">
+      <section class="panel flash flash-error">
         <p>We found a few issues with your story:</p>
         <ul>
-          <% errors.forEach(function(err) { %>
+          <% errors.forEach(function (err) { %>
           <li><%= err %></li>
           <% }) %>
         </ul>
-      </div>
+      </section>
       <% } %>
 
       <form
         id="authorStoryForm"
-        class="builder-form"
+        class="story-builder-form"
         method="post"
         action="<%= builderMode === 'edit' ? `/u/authors/stories/${storyId}` : '/u/authors/stories' %>"
       >
-        <section class="builder-panel">
-          <h2>Story details</h2>
-          <div class="builder-grid">
-            <label>
+        <section class="panel story-details-panel">
+          <h2>Story Details</h2>
+          <div class="story-details-grid">
+            <label class="field">
               <span>Title</span>
-              <input
-                type="text"
-                name="title"
-                value="<%= formData.title || '' %>"
-                required
-              />
+              <input type="text" name="title" value="<%= formData.title || '' %>" required />
             </label>
-            <label>
-              <span>Start node</span>
-              <select name="startNodeId" id="startNodeId">
-                <option value="">Select after adding nodes</option>
+            <label class="field">
+              <span>Start Passage</span>
+              <select name="startNodeId" id="story-start-node">
+                <option value="">-- Select --</option>
               </select>
             </label>
+            <label class="field">
+              <span>Cover Image URL</span>
+              <input
+                type="text"
+                name="coverImage"
+                value="<%= formData.coverImage || '' %>"
+                placeholder="https://example.com/cover.jpg"
+              />
+            </label>
+            <label class="field">
+              <span>Author Notes (private)</span>
+              <textarea
+                name="notes"
+                rows="4"
+                placeholder="Keep track of reminders or drafting notes"
+              ><%= formData.notes || '' %></textarea>
+            </label>
+            <label class="field field--wide field--multiline">
+              <span>Description (public)</span>
+              <textarea
+                name="description"
+                rows="5"
+                placeholder="Give readers a sense of what to expect"
+              ><%= formData.description || '' %></textarea>
+            </label>
           </div>
-
-          <label>
-            <span>Description</span>
-            <textarea
-              name="description"
-              rows="3"
-              placeholder="A quick overview for readers"
-            ><%= formData.description || '' %></textarea>
-          </label>
-
-          <label>
-            <span>Cover image URL</span>
-            <input
-              type="text"
-              name="coverImage"
-              value="<%= formData.coverImage || '' %>"
-              placeholder="https://example.com/cover.jpg"
-            />
-          </label>
-
-          <label>
-            <span>Author notes (optional)</span>
-            <textarea
-              name="notes"
-              rows="3"
-              placeholder="Keep track of ideas or drafting notes"
-            ><%= formData.notes || '' %></textarea>
-          </label>
-
           <% if (Array.isArray(availableCategories) && availableCategories.length) { %>
-          <fieldset class="category-fieldset">
-            <legend>Categories</legend>
-            <div class="category-grid">
+          <div class="field field--wide field--tags">
+            <span>Categories</span>
+            <div class="tag-options">
               <% availableCategories.forEach(function (cat) { %>
-              <label class="category-option">
+              <label class="tag-option">
                 <input
                   type="checkbox"
                   name="categories"
@@ -98,559 +100,172 @@
               </label>
               <% }) %>
             </div>
-          </fieldset>
+          </div>
           <% } %>
         </section>
 
-        <section class="builder-panel">
-          <header class="panel-header">
-            <h2>Passages</h2>
-            <button type="button" class="cta-button small" id="addNodeBtn">
-              + Add passage
-            </button>
-          </header>
-          <p class="muted">
-            Each passage needs a unique ID. Choices link to other passages or
-            endings using those IDs.
-          </p>
-          <div id="nodesContainer" class="builder-stack"></div>
+        <section class="map-panel">
+          <div class="map-controls">
+            <p>
+              Drag passages into place, select a node to edit it, and add choices to
+              build your branching story.
+            </p>
+            <div class="map-controls-right">
+              <div class="map-zoom-controls" role="group" aria-label="Zoom map view">
+                <button type="button" class="btn small ghost icon-only" id="map-zoom-out-btn" aria-label="Zoom out">
+                  <span aria-hidden="true">&minus;</span>
+                </button>
+                <button type="button" class="btn small ghost icon-only" id="map-zoom-in-btn" aria-label="Zoom in">
+                  <span aria-hidden="true">+</span>
+                </button>
+              </div>
+              <button type="button" class="btn small" id="add-node-btn">+ Passage</button>
+              <button type="button" class="btn small" id="add-ending-btn">+ Ending</button>
+              <button type="button" class="btn small ghost" id="center-selection-btn">Center Selection</button>
+            </div>
+          </div>
+          <div class="map-viewport" id="mapViewport">
+            <div class="map-canvas" id="mapCanvas">
+              <svg class="map-links" id="linkLayer"></svg>
+            </div>
+          </div>
         </section>
 
-        <section class="builder-panel">
-          <header class="panel-header">
-            <h2>Endings</h2>
-            <button type="button" class="cta-button small" id="addEndingBtn">
-              + Add ending
-            </button>
-          </header>
-          <div id="endingsContainer" class="builder-stack"></div>
-        </section>
+        <div id="builderDataInputs" class="sr-only" aria-hidden="true"></div>
 
         <div class="builder-actions">
-          <button type="submit" class="cta-button">
-            <%= builderMode === 'edit' ? 'Save changes' : 'Save draft' %>
+          <button type="submit" class="btn primary">
+            <%= builderMode === 'edit' ? 'Save Changes' : 'Save Draft' %>
           </button>
           <p class="muted">
-            Submit your story for review from the Author Library when you're
-            ready to share it.
+            Submit your story for review from your Author Library when you're ready
+            to share it. Stories are private until approved.
           </p>
         </div>
       </form>
     </main>
 
-    <%- include('../partials/footer') %>
-
-    <template id="nodeTemplate">
-      <div class="builder-card" data-node>
-        <div class="builder-card__header">
-          <h3>Passage</h3>
-          <button type="button" class="link remove-node">Remove</button>
+    <div class="entity-editor collapsed hidden" id="entityEditor">
+      <div class="entity-editor__header">
+        <div>
+          <h2 id="entityEditorTitle">Passage</h2>
+          <p class="entity-editor__subtitle" id="entityEditorSubtitle"></p>
         </div>
-        <div class="builder-grid">
-          <label>
-            <span>Node ID</span>
-            <input type="text" data-field="_id" required />
-          </label>
-          <label>
-            <span>Display color</span>
-            <input type="text" data-field="color" placeholder="twilight" />
-          </label>
+        <div class="entity-editor__actions">
+          <button type="button" class="btn small ghost" id="editorCollapseBtn" aria-expanded="false">Expand</button>
+          <button type="button" class="btn small danger hidden" id="node-delete">Delete Passage</button>
+          <button type="button" class="btn small danger hidden" id="ending-delete">Delete Ending</button>
         </div>
-        <label>
-          <span>Passage text</span>
-          <textarea data-field="text" rows="4" required></textarea>
-        </label>
-        <label>
-          <span>Image URL</span>
-          <input type="text" data-field="image" />
-        </label>
-        <label>
-          <span>Notes</span>
-          <textarea data-field="notes" rows="2"></textarea>
-        </label>
-        <div class="choice-list" data-choices></div>
-        <button type="button" class="link add-choice">+ Add choice</button>
       </div>
-    </template>
-
-    <template id="choiceTemplate">
-      <div class="choice-card" data-choice>
-        <div class="builder-grid">
-          <label>
-            <span>Choice label</span>
-            <input type="text" data-choice-field="label" required />
+      <div class="entity-editor__body">
+        <form id="node-form" class="stack hidden" data-editor="node">
+          <label class="field">
+            <span>Passage ID</span>
+            <input type="text" name="_id" required />
           </label>
-          <label>
-            <span>Leads to (node or ending ID)</span>
-            <input type="text" data-choice-field="nextNodeId" required />
-          </label>
-        </div>
-        <div class="choice-options">
-          <label class="choice-lock">
-            <input type="checkbox" data-choice-field="locked" />
-            Locked choice
-          </label>
-          <label class="choice-cost">
-            <span>Unlock cost</span>
-            <input type="number" min="0" data-choice-field="unlockCost" value="0" />
-          </label>
-        </div>
-        <button type="button" class="link remove-choice">Remove choice</button>
-        <input type="hidden" data-choice-field="_id" />
-      </div>
-    </template>
-
-    <template id="endingTemplate">
-      <div class="builder-card" data-ending>
-        <div class="builder-card__header">
-          <h3>Ending</h3>
-          <button type="button" class="link remove-ending">Remove</button>
-        </div>
-        <div class="builder-grid">
-          <label>
-            <span>Ending ID</span>
-            <input type="text" data-ending-field="_id" required />
-          </label>
-          <label>
-            <span>Label</span>
-            <input type="text" data-ending-field="label" required />
-          </label>
-          <label>
-            <span>Type</span>
-            <select data-ending-field="type">
-              <option value="true">True</option>
-              <option value="death">Death</option>
-              <option value="secret">Secret</option>
-              <option value="other" selected>Other</option>
+          <label class="field">
+            <span>Border Color</span>
+            <select name="color">
+              <option value="twilight">Twilight Violet</option>
+              <option value="ember">Ember Orange</option>
+              <option value="moss">Moss Green</option>
+              <option value="dusk">Dusk Blue</option>
+              <option value="rose">Rose Magenta</option>
+              <option value="slate">Slate Gray</option>
             </select>
           </label>
+          <label class="field">
+            <span>Image URL</span>
+            <input type="text" name="image" placeholder="https://example.com/image.jpg" />
+          </label>
+          <label class="field field--multiline">
+            <span>Story Text</span>
+            <textarea name="text" rows="10" class="monospace"></textarea>
+          </label>
+          <label class="field field--multiline">
+            <span>Author Notes</span>
+            <textarea name="notes" rows="5" placeholder="Optional notes just for you"></textarea>
+          </label>
+        </form>
+
+        <div class="choices-block hidden" data-editor="node">
+          <div class="empty-state" id="choicesEmptyState">No choices yet.</div>
+          <div id="choice-list"></div>
+          <form id="choice-add-form" class="choice-form">
+            <div class="choice-fields">
+              <label class="choice-field">
+                <span>Choice ID (optional)</span>
+                <input type="text" name="_id" placeholder="auto-generated" />
+              </label>
+              <label class="choice-field choice-field--label">
+                <span>Label</span>
+                <input type="text" name="label" placeholder="Choice label" required />
+              </label>
+              <label class="choice-field">
+                <span>Next</span>
+                <select name="nextNodeId" required></select>
+              </label>
+              <label class="choice-field choice-field--toggle">
+                <span>Locked</span>
+                <input type="checkbox" name="locked" data-lock-toggle />
+              </label>
+              <label class="choice-field choice-field--cost">
+                <span>Unlock Cost</span>
+                <input type="number" name="unlockCost" min="0" step="1" value="0" data-lock-cost />
+              </label>
+            </div>
+            <div class="choice-actions">
+              <button type="submit" class="btn small">Add Choice</button>
+            </div>
+          </form>
         </div>
-        <label>
-          <span>Ending text</span>
-          <textarea data-ending-field="text" rows="3"></textarea>
-        </label>
-        <label>
-          <span>Notes</span>
-          <textarea data-ending-field="notes" rows="2"></textarea>
-        </label>
+
+        <form id="ending-form" class="stack hidden" data-editor="ending">
+          <label class="field">
+            <span>Ending ID</span>
+            <input type="text" name="_id" required />
+          </label>
+          <label class="field">
+            <span>Ending Label</span>
+            <input type="text" name="label" placeholder="Displayed title" />
+          </label>
+          <label class="field">
+            <span>Ending Type</span>
+            <select name="type">
+              <option value="true">True Ending</option>
+              <option value="death">Death</option>
+              <option value="secret">Secret</option>
+              <option value="other">Other</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Image URL</span>
+            <input type="text" name="image" placeholder="https://example.com/image.jpg" />
+          </label>
+          <label class="field field--multiline">
+            <span>Ending Text</span>
+            <textarea name="text" rows="10" class="monospace"></textarea>
+          </label>
+          <label class="field field--multiline">
+            <span>Author Notes</span>
+            <textarea name="notes" rows="5" placeholder="Optional notes"></textarea>
+          </label>
+        </form>
       </div>
-    </template>
+    </div>
 
-    <script>
-      window.initialStoryData = <%- JSON.stringify(formData || {}) %>;
-    </script>
-    <script>
-      (function () {
-        const data = window.initialStoryData || {};
-        const nodesContainer = document.getElementById('nodesContainer');
-        const endingsContainer = document.getElementById('endingsContainer');
-        const addNodeBtn = document.getElementById('addNodeBtn');
-        const addEndingBtn = document.getElementById('addEndingBtn');
-        const nodeTemplate = document.getElementById('nodeTemplate');
-        const choiceTemplate = document.getElementById('choiceTemplate');
-        const endingTemplate = document.getElementById('endingTemplate');
-        const startNodeSelect = document.getElementById('startNodeId');
+    <%- include('../partials/footer') %>
 
-        function updateStartNodeOptions() {
-          const current = startNodeSelect.value;
-          startNodeSelect.innerHTML = '';
-          const placeholder = document.createElement('option');
-          placeholder.value = '';
-          placeholder.textContent = 'Select after adding nodes';
-          startNodeSelect.appendChild(placeholder);
-
-          const nodeIds = [];
-          nodesContainer.querySelectorAll('[data-node]').forEach((nodeEl) => {
-            const idInput = nodeEl.querySelector('[data-field="_id"]');
-            if (idInput && idInput.value.trim()) {
-              nodeIds.push(idInput.value.trim());
-            }
-          });
-
-          nodeIds.forEach((id) => {
-            const option = document.createElement('option');
-            option.value = id;
-            option.textContent = id;
-            if (id === current) {
-              option.selected = true;
-            }
-            startNodeSelect.appendChild(option);
-          });
-
-          if (!startNodeSelect.value && nodeIds.length > 0) {
-            startNodeSelect.value = nodeIds[0];
-          }
-        }
-
-        function syncNodeNames() {
-          nodesContainer.querySelectorAll('[data-node]').forEach((nodeEl, nodeIndex) => {
-            nodeEl.querySelectorAll('[data-field]').forEach((input) => {
-              const field = input.dataset.field;
-              input.name = `nodes[${nodeIndex}][${field}]`;
-            });
-
-            nodeEl.querySelectorAll('[data-choice]').forEach((choiceEl, choiceIndex) => {
-              choiceEl.querySelectorAll('[data-choice-field]').forEach((input) => {
-                const field = input.dataset.choiceField;
-                input.name = `nodes[${nodeIndex}][choices][${choiceIndex}][${field}]`;
-              });
-
-              const lockCheckbox = choiceEl.querySelector('[data-choice-field="locked"]');
-              const costField = choiceEl.querySelector('[data-choice-field="unlockCost"]');
-              if (costField) {
-                costField.disabled = !(lockCheckbox && lockCheckbox.checked);
-              }
-            });
-          });
-
-          updateStartNodeOptions();
-        }
-
-        function syncEndingNames() {
-          endingsContainer.querySelectorAll('[data-ending]').forEach((endingEl, endingIndex) => {
-            endingEl.querySelectorAll('[data-ending-field]').forEach((input) => {
-              const field = input.dataset.endingField;
-              input.name = `endings[${endingIndex}][${field}]`;
-            });
-          });
-        }
-
-        function createChoice(choice = {}) {
-          const clone = choiceTemplate.content.firstElementChild.cloneNode(true);
-          clone.querySelectorAll('[data-choice-field]').forEach((input) => {
-            const field = input.dataset.choiceField;
-            if (field === '_id' && choice._id) {
-              input.value = choice._id;
-            }
-            if (field === 'label') input.value = choice.label || '';
-            if (field === 'nextNodeId') input.value = choice.nextNodeId || '';
-            if (field === 'locked') input.checked = Boolean(choice.locked);
-            if (field === 'unlockCost') input.value = Number(choice.unlockCost || 0);
-          });
-          clone.querySelector('.remove-choice').addEventListener('click', () => {
-            clone.remove();
-            syncNodeNames();
-          });
-          const lockCheckbox = clone.querySelector('[data-choice-field="locked"]');
-          const costField = clone.querySelector('[data-choice-field="unlockCost"]');
-          if (lockCheckbox && costField) {
-            lockCheckbox.addEventListener('change', () => {
-              costField.disabled = !lockCheckbox.checked;
-              if (!lockCheckbox.checked) {
-                costField.value = 0;
-              }
-            });
-            costField.disabled = !lockCheckbox.checked;
-          }
-          return clone;
-        }
-
-        function createNode(node = {}) {
-          const clone = nodeTemplate.content.firstElementChild.cloneNode(true);
-          clone.querySelectorAll('[data-field]').forEach((input) => {
-            const field = input.dataset.field;
-            if (field === '_id') input.value = node._id || '';
-            if (field === 'text') input.value = node.text || '';
-            if (field === 'image') input.value = node.image || '';
-            if (field === 'notes') input.value = node.notes || '';
-            if (field === 'color') input.value = node.color || '';
-          });
-
-          const choicesContainer = clone.querySelector('[data-choices]');
-          const nodeChoices = Array.isArray(node.choices) ? node.choices : [];
-          if (nodeChoices.length === 0) {
-            choicesContainer.appendChild(createChoice());
-          } else {
-            nodeChoices.forEach((choice) => {
-              choicesContainer.appendChild(createChoice(choice));
-            });
-          }
-
-          clone.querySelector('.add-choice').addEventListener('click', () => {
-            choicesContainer.appendChild(createChoice());
-            syncNodeNames();
-          });
-
-          clone.querySelector('.remove-node').addEventListener('click', () => {
-            clone.remove();
-            syncNodeNames();
-          });
-
-          return clone;
-        }
-
-        function createEnding(ending = {}) {
-          const clone = endingTemplate.content.firstElementChild.cloneNode(true);
-          clone.querySelectorAll('[data-ending-field]').forEach((input) => {
-            const field = input.dataset.endingField;
-            if (field === '_id') input.value = ending._id || '';
-            if (field === 'label') input.value = ending.label || '';
-            if (field === 'type') input.value = ending.type || 'other';
-            if (field === 'text') input.value = ending.text || '';
-            if (field === 'notes') input.value = ending.notes || '';
-          });
-          clone.querySelector('.remove-ending').addEventListener('click', () => {
-            clone.remove();
-            syncEndingNames();
-          });
-          return clone;
-        }
-
-        addNodeBtn.addEventListener('click', () => {
-          nodesContainer.appendChild(createNode());
-          syncNodeNames();
-        });
-
-        addEndingBtn.addEventListener('click', () => {
-          endingsContainer.appendChild(createEnding());
-          syncEndingNames();
-        });
-
-        const initialNodes = Array.isArray(data.nodes) ? data.nodes : [];
-        if (initialNodes.length === 0) {
-          nodesContainer.appendChild(createNode());
-        } else {
-          initialNodes.forEach((node) => {
-            nodesContainer.appendChild(createNode(node));
-          });
-        }
-
-        const initialEndings = Array.isArray(data.endings) ? data.endings : [];
-        if (initialEndings.length === 0) {
-          endingsContainer.appendChild(createEnding());
-        } else {
-          initialEndings.forEach((ending) => {
-            endingsContainer.appendChild(createEnding(ending));
-          });
-        }
-
-        syncNodeNames();
-        syncEndingNames();
-
-        if (data.startNodeId) {
-          startNodeSelect.value = data.startNodeId;
-        }
-      })();
-    </script>
-
-    <style>
-      .story-builder {
-        padding-bottom: 4rem;
-        display: flex;
-        flex-direction: column;
-        gap: 1.75rem;
-      }
-
-      .builder-form {
-        display: flex;
-        flex-direction: column;
-        gap: 2rem;
-      }
-
-      .builder-panel {
-        padding: 1.75rem;
-        border-radius: 18px;
-        background: rgba(17, 24, 39, 0.85);
-        border: 1px solid rgba(148, 163, 184, 0.18);
-        box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
-        display: flex;
-        flex-direction: column;
-        gap: 1.25rem;
-      }
-
-      .panel-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 1rem;
-      }
-
-      .builder-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 1rem;
-      }
-
-      .builder-grid label,
-      .builder-panel label,
-      .builder-panel textarea,
-      .builder-panel input {
-        width: 100%;
-      }
-
-      label span,
-      legend {
-        font-size: 0.85rem;
-        font-weight: 600;
-        letter-spacing: 0.05em;
-        text-transform: uppercase;
-        color: rgba(148, 163, 184, 0.85);
-        display: block;
-        margin-bottom: 0.35rem;
-      }
-
-      input[type='text'],
-      input[type='number'],
-      select,
-      textarea {
-        border-radius: 12px;
-        border: 1px solid rgba(148, 163, 184, 0.25);
-        background: rgba(15, 23, 42, 0.85);
-        color: #e2e8f0;
-        padding: 0.65rem 0.8rem;
-        font-size: 0.95rem;
-      }
-
-      textarea {
-        min-height: 120px;
-      }
-
-      .builder-stack {
-        display: grid;
-        gap: 1rem;
-      }
-
-      .builder-card {
-        border: 1px solid rgba(148, 163, 184, 0.2);
-        background: rgba(30, 41, 59, 0.6);
-        border-radius: 16px;
-        padding: 1.25rem;
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-      }
-
-      .builder-card__header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 1rem;
-      }
-
-      .builder-card__header h3 {
-        margin: 0;
-        font-size: 1.1rem;
-      }
-
-      .choice-card {
-        border: 1px dashed rgba(148, 163, 184, 0.35);
-        border-radius: 14px;
-        padding: 1rem;
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-        background: rgba(15, 23, 42, 0.55);
-      }
-
-      .choice-options {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: 1rem;
-      }
-
-      .choice-lock {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.4rem;
-        font-size: 0.9rem;
-      }
-
-      .choice-cost {
-        flex: 1 1 120px;
-      }
-
-      .choice-cost input {
-        width: 100%;
-      }
-
-      .category-fieldset {
-        border: 1px solid rgba(148, 163, 184, 0.25);
-        border-radius: 14px;
-        padding: 1rem 1.25rem;
-      }
-
-      .category-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-        gap: 0.5rem 1rem;
-      }
-
-      .category-option {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.45rem;
-        font-size: 0.9rem;
-      }
-
-      .builder-actions {
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        align-items: flex-start;
-      }
-
-      .flash {
-        padding: 1rem 1.25rem;
-        border-radius: 14px;
-      }
-
-      .flash-error {
-        border: 1px solid rgba(248, 113, 113, 0.35);
-        background: rgba(248, 113, 113, 0.12);
-        color: #fecaca;
-      }
-
-      .link {
-        background: none;
-        border: none;
-        color: #93c5fd;
-        cursor: pointer;
-        font-size: 0.9rem;
-        text-decoration: underline;
-      }
-
-      .story-status {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        padding: 0.35rem 0.85rem;
-        border-radius: 999px;
-        border: 1px solid rgba(148, 163, 184, 0.35);
-        color: #e2e8f0;
-        background: rgba(148, 163, 184, 0.12);
-        width: fit-content;
-      }
-
-      .story-status-public {
-        background: rgba(34, 197, 94, 0.18);
-        border-color: rgba(34, 197, 94, 0.32);
-        color: #bbf7d0;
-      }
-
-      .story-status-pending,
-      .story-status-coming_soon {
-        background: rgba(59, 130, 246, 0.18);
-        border-color: rgba(59, 130, 246, 0.32);
-        color: #c7d2fe;
-      }
-
-      .story-status-under_review {
-        background: rgba(244, 114, 182, 0.18);
-        border-color: rgba(244, 114, 182, 0.32);
-        color: #fbcfe8;
-      }
-
-      @media (max-width: 720px) {
-        .builder-grid {
-          grid-template-columns: 1fr;
-        }
-
-        .choice-options {
-          flex-direction: column;
-          align-items: stretch;
-        }
-      }
-    </style>
+    <script id="builder-data" type="application/json"><%- JSON.stringify({
+      title: formData.title || '',
+      description: formData.description || '',
+      notes: formData.notes || '',
+      coverImage: formData.coverImage || '',
+      categories: formData.categories || [],
+      startNodeId: formData.startNodeId || '',
+      nodes: formData.nodes || [],
+      endings: formData.endings || []
+    }) %></script>
+    <script src="/js/authorBuilder.js"></script>
   </body>
 </html>

--- a/views/user/storyBuilder.ejs
+++ b/views/user/storyBuilder.ejs
@@ -46,6 +46,7 @@
         id="authorStoryForm"
         class="story-builder-form"
         method="post"
+        data-story-id="<%= builderMode === 'edit' ? storyId : '' %>"
         action="<%= builderMode === 'edit' ? `/u/authors/stories/${storyId}` : '/u/authors/stories' %>"
       >
         <section class="panel story-details-panel">
@@ -186,7 +187,7 @@
         <div class="choices-block hidden" data-editor="node">
           <div class="empty-state" id="choicesEmptyState">No choices yet.</div>
           <div id="choice-list"></div>
-          <form id="choice-add-form" class="choice-form">
+          <form id="choice-add-form" class="choice-form" data-editor="node">
             <div class="choice-fields">
               <label class="choice-field choice-field--label">
                 <span>Label</span>

--- a/views/user/storyBuilder.ejs
+++ b/views/user/storyBuilder.ejs
@@ -217,16 +217,12 @@
             <input type="text" name="_id" required />
           </label>
           <label class="field">
-            <span>Ending Label</span>
-            <input type="text" name="label" placeholder="Displayed title" />
-          </label>
-          <label class="field">
             <span>Ending Type</span>
             <select name="type">
-              <option value="true">True Ending</option>
+              <option value="true">True</option>
               <option value="death">Death</option>
-              <option value="secret">Secret</option>
               <option value="other">Other</option>
+              <option value="secret">Secret</option>
             </select>
           </label>
           <label class="field">

--- a/views/user/storyBuilder.ejs
+++ b/views/user/storyBuilder.ejs
@@ -22,6 +22,9 @@
         </div>
         <div class="toolbar-group">
           <a href="/u/authors" class="btn ghost">Back to Author Library</a>
+          <% if (imageLibraryUrl) { %>
+          <a href="<%= imageLibraryUrl %>" class="btn ghost">Manage Images</a>
+          <% } %>
           <button type="submit" form="authorStoryForm" class="btn primary">
             <%= builderMode === 'edit' ? 'Save Changes' : 'Save Draft' %>
           </button>
@@ -59,13 +62,15 @@
               </select>
             </label>
             <label class="field">
-              <span>Cover Image URL</span>
-              <input
-                type="text"
-                name="coverImage"
-                value="<%= formData.coverImage || '' %>"
-                placeholder="https://example.com/cover.jpg"
-              />
+              <span>Cover Image</span>
+              <select name="coverImage" id="story-cover-image"></select>
+              <span class="field-hint">
+                <% if (imageLibraryUrl) { %>
+                Add new artwork from the Manage Images panel.
+                <% } else { %>
+                Upload images once your draft is created.
+                <% } %>
+              </span>
             </label>
             <label class="field">
               <span>Author Notes (private)</span>
@@ -175,8 +180,8 @@
             </select>
           </label>
           <label class="field">
-            <span>Image URL</span>
-            <input type="text" name="image" placeholder="https://example.com/image.jpg" />
+            <span>Image</span>
+            <select name="image"></select>
           </label>
           <label class="field field--multiline">
             <span>Story Text</span>
@@ -186,6 +191,9 @@
             <span>Author Notes</span>
             <textarea name="notes" rows="5" placeholder="Optional notes just for you"></textarea>
           </label>
+          <div class="form-actions">
+            <button type="submit" class="btn small">Save Passage</button>
+          </div>
         </form>
 
         <div class="choices-block hidden" data-editor="node">
@@ -239,8 +247,8 @@
             </select>
           </label>
           <label class="field">
-            <span>Image URL</span>
-            <input type="text" name="image" placeholder="https://example.com/image.jpg" />
+            <span>Image</span>
+            <select name="image"></select>
           </label>
           <label class="field field--multiline">
             <span>Ending Text</span>
@@ -250,6 +258,9 @@
             <span>Author Notes</span>
             <textarea name="notes" rows="5" placeholder="Optional notes"></textarea>
           </label>
+          <div class="form-actions">
+            <button type="submit" class="btn small">Save Ending</button>
+          </div>
         </form>
       </div>
     </div>
@@ -264,7 +275,8 @@
       categories: formData.categories || [],
       startNodeId: formData.startNodeId || '',
       nodes: formData.nodes || [],
-      endings: formData.endings || []
+      endings: formData.endings || [],
+      images: imageOptions || []
     }) %></script>
     <script src="/js/authorBuilder.js"></script>
   </body>

--- a/views/user/storyLanding.ejs
+++ b/views/user/storyLanding.ejs
@@ -8,6 +8,13 @@
     <%- include('../partials/header', { user }) %>
 
     <main class="container">
+      <% if (adminPreview && storyAccess && storyAccess.isAdmin) { %>
+      <div class="admin-preview-banner">
+        <a href="<%= adminReturnUrl || '/admin' %>" class="cta-button ghost"
+          >&larr; Back to Dashboard</a
+        >
+      </div>
+      <% } %>
       <% const access = storyAccess || {}; %>
       <h1><%= story?.title || 'Untitled Story' %></h1>
       <img
@@ -167,6 +174,16 @@
         margin-top: 2.5rem;
         font-size: 0.85rem;
         color: rgba(148, 163, 184, 0.85);
+      }
+
+      .admin-preview-banner {
+        margin: 1rem 0 1.5rem;
+      }
+
+      .admin-preview-banner .cta-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
       }
     </style>
   </body>

--- a/views/user/storyLanding.ejs
+++ b/views/user/storyLanding.ejs
@@ -8,6 +8,7 @@
     <%- include('../partials/header', { user }) %>
 
     <main class="container">
+      <% const access = storyAccess || {}; %>
       <h1><%= story?.title || 'Untitled Story' %></h1>
       <img
         src="<%= story?.coverImage || '/images/default-cover.svg' %>"
@@ -15,6 +16,15 @@
         alt="Cover image for <%= story?.title || 'story' %>"
       />
       <p><%= story?.description || '' %></p>
+
+      <% if (access && access.status && access.status !== 'public') { %>
+      <div class="story-status-banner story-status-<%= access.status %>">
+        <span class="story-status-label"><%= access.statusLabel %></span>
+        <% if (access.isOwner && access.canPlay && access.isUserStory) { %>
+        <small>You can preview your own story even while it's under review.</small>
+        <% } %>
+      </div>
+      <% } %>
 
       <% if (Array.isArray(story?.categories) && story.categories.length) { %>
       <section class="story-categories">
@@ -39,16 +49,33 @@
       <% } %>
 
       <div class="actions stack">
-        <% if (startNodeId) { %>
+        <% if (access.canPlay && startNodeId) { %>
         <a
           href="/u/play/<%= story._id %>/<%= startNodeId %>"
           class="cta-button"
         >
           Start from Beginning
         </a>
-        <% } else { %>
+        <% } else if (!access.canPlay) { %>
+        <div class="story-status-message story-status-<%= access.status %>">
+          <span class="story-status-label"><%= access.statusLabel %></span>
+          <p class="muted">
+            <% if (access.status === 'pending') { %>
+            This story is pending review and will be available soon.
+            <% } else if (access.status === 'under_review') { %>
+            This story is currently under review.
+            <% } else if (access.status === 'coming_soon') { %>
+            This adventure is coming soon. Check back later!
+            <% } else { %>
+            This story is not available to play right now.
+            <% } %>
+          </p>
+        </div>
+        <% } else if (!startNodeId) { %>
         <p class="muted">This story doesn't have a starting node yet.</p>
-        <% } %> <% if (continueNodeId) { %>
+        <% } %>
+
+        <% if (access.canPlay && continueNodeId) { %>
         <a
           href="/u/play/<%= story._id %>/<%= continueNodeId %>"
           class="cta-button ghost"


### PR DESCRIPTION
## Summary
- expose a dedicated Authors area with story builder and author library so users can draft, submit, and manage their own adventures
- surface community submissions in the user library and add admin tools to approve, reject, or pull public user stories
- track Author Gems alongside standard gems and charge them for locked paths in user-created stories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7dd3a69408332a35258e191c5dbc8