### PR TITLE
Integrate Firebase authentication and Google sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,93 +1,96 @@
-# 🌒 Shadow Paths — A Choose Your Own Adventure Platform
+# 🌒 Shadow Paths — A Full-Stack Interactive Storytelling Platform
 
-**Shadow Paths** is a web-based interactive storytelling platform inspired by _D&D_, _dark fantasy_, and _spooky adventure tales_.  
-Players can create accounts, explore branching stories, and unlock multiple endings — while their progress, stats, and discoveries are saved automatically.  
-Admins can manage users, upload story images, and build stories with flexible node-based structures.
-
-🔗 **Live Demo:** [https://adventurestory.onrender.com/](https://adventurestory.onrender.com/)
+Shadow Paths is a portfolio-grade, MERN-inspired choose-your-own-adventure engine that blends a Twine-style authoring experience with a production-ready player portal. Built with Node.js, Express, MongoDB, and rich client-side motion, it lets players dive into branching tales while creators craft elaborate storylines backed by real-time persistence and cloud integrations.
 
 ---
 
-## ✨ Features
+## 🧭 Platform Overview
 
-### 🧍 Player Experience
+### Player Experience
+- **Firebase Authentication** with email/password, Google sign-in, password resets, and email verification.
+- **Progression Tracking** that records endings found, medals earned, and stories created or published per account.
+- **Trophies & Dual Currencies** featuring Gems and Author Gems for unlocking premium story branches.
+- **Unlockable Paths** that gate secret nodes or finales behind earned currency requirements.
 
-- **User Accounts**
+### Creator Tools
+- **Node Story Builder** delivering a Twine-style grid editor for branching narratives.
+- **Cloudinary-Powered Media** uploads for cover art, scene imagery, and atmospheric assets.
+- **Real-Time MongoDB Saving** so story drafts, node changes, and metadata persist instantly.
 
-  - Sign up, log in, and log out securely
-  - Session persistence using Express Sessions + MongoDB
-  - Profile stats showing total endings, medals, and story progress
-
-- **Story Library**
-
-  - Browse all available stories with cover art and descriptions
-  - Stories display discovered vs total endings
-  - Automatically offers **“Continue where you left off”** if a player hasn’t finished
-  - **“Start from Beginning”** appears only once a story is completed or reset
-  - Stories maintain admin-defined display order
-
-- **Game Progression**
-  - Stories feature multiple endings (true, death, secret, etc.)
-  - In-game currency awarded for completing endings and earning medals
-  - Tracks total endings, medals, and story completion across all adventures
+### Admin Tools
+- **User & Library Management** dashboards for moderating accounts and curating story libraries.
+- **Content Oversight** to approve community stories and surface featured adventures.
+- **Resend-Powered Inbox** for handling contact forms, support escalations, and platform updates.
 
 ---
 
-### ⚙️ Admin Tools
+## 🛠️ Tech Stack
 
-- **Story Management**
-
-  - Create and edit story entries and branching nodes
-  - Add, reorder, and delete story images
-  - Integrated **Cloudinary** upload system (secure `.env` keys)
-  - Story library reflects admin-defined display order
-
-- **User Management**
-  - View all users and toggle admin status
-  - See user progress and endings completed
-
----
-
-## 🧩 Tech Stack
-
-| Layer             | Technology                               |
-| ----------------- | ---------------------------------------- |
-| **Frontend**      | EJS templating • HTML • CSS              |
-| **Backend**       | Node.js • Express                        |
-| **Database**      | MongoDB • Mongoose                       |
-| **Auth**          | express-session • connect-mongo • bcrypt |
-| **Cloud Storage** | Cloudinary (image hosting + management)  |
-| **Dev Tools**     | nodemon • dotenv • seed scripts          |
+| Layer          | Technology                                                |
+| -------------- | --------------------------------------------------------- |
+| **Frontend**   | EJS • HTML • CSS • JavaScript                              |
+| **Backend**    | Node.js • Express                                         |
+| **Database**   | MongoDB + Mongoose                                        |
+| **Auth**       | Firebase Auth • bcrypt • express-session                   |
+| **Cloud Storage** | Cloudinary                                             |
+| **Email**      | Resend API                                                |
+| **Hosting**    | Render.com                                                |
+| **Dev Tools**  | Nodemon • dotenv • GitHub CI/CD                           |
+| **AI**         | OpenAI Codex                                              |
 
 ---
 
 ## 🚀 Getting Started
 
-### Prerequisites
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/GreenHouse007/AdventureStory.git
+   cd AdventureStory
+   ```
 
-- Node.js 18+
-- MongoDB (local or Atlas)
-- Cloudinary account (for image hosting)
+2. **Install dependencies**
+   ```bash
+   npm install
+   ```
 
-### Installation
+3. **Configure environment variables**
+   Create a `.env` file in the project root with the following keys:
+   ```env
+   MONGODB_URI=<your-mongodb-connection-string>
+   SESSION_SECRET=<random-session-secret>
+   CLOUDINARY_CLOUD_NAME=<cloudinary-cloud-name>
+   CLOUDINARY_API_KEY=<cloudinary-api-key>
+   CLOUDINARY_API_SECRET=<cloudinary-api-secret>
+   RESEND_API_KEY=<resend-api-key>
+   FIREBASE_PROJECT_ID=<firebase-project-id>
+   FIREBASE_CLIENT_EMAIL=<firebase-service-account-client-email>
+   FIREBASE_PRIVATE_KEY="<firebase-service-account-private-key>"
+   FIREBASE_API_KEY=<firebase-web-api-key>
+   FIREBASE_AUTH_DOMAIN=<firebase-auth-domain>
+   FIREBASE_STORAGE_BUCKET=<firebase-storage-bucket>
+   FIREBASE_MESSAGING_SENDER_ID=<firebase-messaging-sender-id>
+   FIREBASE_APP_ID=<firebase-app-id>
+   FIREBASE_MEASUREMENT_ID=<firebase-measurement-id>
+   ```
 
-```bash
-git clone https://github.com/yourusername/shadow-paths.git
-cd shadow-paths
-npm install
+4. **Run the development server**
+   ```bash
+   npm run dev
+   ```
+   The app boots with nodemon, hot-reloading server changes and serving the latest assets.
 
-```
+---
 
-## 🧠 Roadmap
+## 🗺️ Roadmap
+- Trophy progression refinements with rarity tiers and seasonal challenges.
+- Expanded currency unlocks for branching finales and author monetization.
+- Immersive audio narration and adaptive ambient soundscapes.
+- Collectible badges and profile showcases for completions.
+- REST/GraphQL API for importing and exporting story blueprints.
+- Competitive leaderboards tracking speed-runs, endings, and creative output.
 
-Player progress reset option
+---
 
-Visual branching editor for story nodes
+## 💡 Developer Notes
 
-Achievements and collectible badges
-
-Audio narration and ambient sound system
-
-Premium story unlocks using earned currency
-
-API for importing/exporting stories
+Shadow Paths has grown from a simple choose-your-own-adventure prototype into a feature-rich storytelling engine that fuses database persistence, cloud media management, email automation, and Firebase-authenticated sessions. Iterative enhancements—many assisted by OpenAI Codex—have layered in responsive UI, cinematic motion, and professional tooling to produce a platform ready for production use or collaborative expansion.

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const express = require("express");
 const path = require("path");
 const routes = require("./routes");
 const { getReturnPath } = require("./utils/navigation");
+const { buildFirebaseConfig } = require("./utils/firebaseConfig");
 
 require("dotenv").config();
 const connectDB = require("./db");
@@ -16,6 +17,11 @@ app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 // serve static files (css, images, etc.)
 app.use(express.static(path.join(__dirname, "public")));
+
+app.use((req, res, next) => {
+  res.locals.firebaseConfig = buildFirebaseConfig();
+  next();
+});
 
 // connect to database
 connectDB();

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -1,47 +1,162 @@
-const bcrypt = require("bcrypt");
+const crypto = require("crypto");
 const User = require("../models/user.model");
+const firebaseAdmin = require("../utils/firebaseAdmin");
+const { buildFirebaseConfig } = require("../utils/firebaseConfig");
 
-// show signup form
-exports.signupGet = (req, res) => {
-  res.render("public/signup", { title: "Sign Up" });
+const ONE_DAY_MS = 1000 * 60 * 60 * 24;
+const THIRTY_DAYS_MS = ONE_DAY_MS * 30;
+
+const renderWithFirebase = (res, view, locals = {}) =>
+  res.render(view, {
+    ...locals,
+    firebaseConfig: buildFirebaseConfig(),
+  });
+
+const verifyIdToken = async (idToken) => {
+  try {
+    return await firebaseAdmin.auth().verifyIdToken(idToken);
+  } catch (error) {
+    const err = new Error("Invalid or expired Firebase ID token");
+    err.status = 401;
+    throw err;
+  }
 };
 
-// handle signup form submission
+const sanitizeUsername = (input) => {
+  if (!input) return "adventurer";
+  const normalized = input
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return normalized.length >= 3 ? normalized.slice(0, 24) : "adventurer";
+};
+
+const generateAvailableUsername = async (base) => {
+  const sanitizedBase = sanitizeUsername(base);
+  let candidate = sanitizedBase;
+  let suffix = 0;
+
+  // Try sequential suffixes before falling back to a random hash
+  while (await User.exists({ username: candidate })) {
+    suffix += 1;
+    if (suffix > 25) {
+      const random = crypto.randomBytes(3).toString("hex");
+      candidate = `${sanitizedBase}_${random}`;
+      if (!(await User.exists({ username: candidate }))) {
+        break;
+      }
+    } else {
+      candidate = `${sanitizedBase}${suffix}`.slice(0, 32);
+    }
+  }
+
+  return candidate;
+};
+
+const attachFirebaseUid = async ({ firebaseUid, email, usernameHint }) => {
+  let user = await User.findOne({ firebaseUid });
+
+  if (!user && email) {
+    user = await User.findOne({ email });
+  }
+
+  if (!user && email) {
+    const base = usernameHint || (email ? email.split("@")[0] : "adventurer");
+    const username = await generateAvailableUsername(base);
+    user = await User.create({ username, email, firebaseUid });
+  } else if (!user) {
+    const username = await generateAvailableUsername(usernameHint || "adventurer");
+    user = await User.create({ username, firebaseUid, email: `${firebaseUid}@placeholder.local` });
+  } else {
+    if (!user.firebaseUid) {
+      user.firebaseUid = firebaseUid;
+    }
+    if (email && user.email !== email) {
+      user.email = email;
+    }
+    await user.save();
+  }
+
+  return user;
+};
+
+const persistSession = (req, { userId, remember }) =>
+  new Promise((resolve, reject) => {
+    req.session.userId = userId;
+    req.session.cookie.maxAge = remember ? THIRTY_DAYS_MS : ONE_DAY_MS;
+    req.session.save((err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+exports.signupGet = (req, res) => {
+  renderWithFirebase(res, "public/signup", {
+    title: "Sign Up",
+    user: req.user,
+    old: {},
+  });
+};
+
 exports.signupPost = async (req, res) => {
-  const { username, email, password } = req.body;
+  const { idToken, username } = req.body;
+
+  if (!idToken || !username) {
+    return res.status(400).json({ error: "Missing Firebase token or username." });
+  }
+
   try {
-    // hash the password
-    const passwordHash = await bcrypt.hash(password, 12);
-
-    // create user in MongoDB
-    const user = await User.create({ username, email, passwordHash });
-
-    // store user ID in session (logs them in)
-    req.session.userId = user._id;
-    await req.session.save();
-    res.redirect("/u/library"); // send to their library
-  } catch (err) {
-    console.error(err);
-
-    // if duplicate email or username
-    if (err.code === 11000) {
-      return res.status(400).render("public/signup", {
-        title: "Sign Up",
-        error: "Username or email already exists.",
-        old: { username, email },
-      });
+    const decoded = await verifyIdToken(idToken);
+    const email = decoded.email;
+    if (!email) {
+      return res.status(400).json({ error: "A verified email address is required." });
     }
 
-    res.status(500).render("public/signup", {
-      title: "Sign Up",
-      error: "Something went wrong. Please try again.",
-      old: { username, email },
-    });
+    const usernameOwner = await User.findOne({ username });
+    if (usernameOwner) {
+      const belongsToRequester =
+        String(usernameOwner.firebaseUid || "") === decoded.uid ||
+        usernameOwner.email === email;
+      if (!belongsToRequester) {
+        return res.status(400).json({ error: "That username is already taken." });
+      }
+    }
+
+    let user = await User.findOne({ firebaseUid: decoded.uid });
+    if (!user) {
+      user = await User.findOne({ email });
+    }
+
+    if (!user) {
+      user = await User.create({ username, email, firebaseUid: decoded.uid });
+    } else {
+      if (!user.firebaseUid) {
+        user.firebaseUid = decoded.uid;
+      }
+      if (!user.username) {
+        user.username = username;
+      }
+      if (user.email !== email) {
+        user.email = email;
+      }
+      await user.save();
+    }
+
+    await persistSession(req, { userId: user._id, remember: true });
+    res.json({ redirect: "/u/library" });
+  } catch (error) {
+    console.error("Signup error:", error);
+    const status = error.status || 500;
+    res.status(status).json({ error: error.message || "Unable to complete signup." });
   }
 };
 
 exports.loginGet = (req, res) => {
-  res.render("public/login", {
+  renderWithFirebase(res, "public/login", {
     title: "Login",
     user: req.user,
     old: {},
@@ -49,58 +164,30 @@ exports.loginGet = (req, res) => {
   });
 };
 
-const ONE_DAY_MS = 1000 * 60 * 60 * 24;
-const THIRTY_DAYS_MS = ONE_DAY_MS * 30;
-
 exports.loginPost = async (req, res) => {
-  const { email, password, remember } = req.body;
+  const { idToken, remember } = req.body;
+
+  if (!idToken) {
+    return res.status(400).json({ error: "Missing Firebase token." });
+  }
+
   try {
-    const user = await User.findOne({ email });
-    if (!user) {
-      return res.status(401).render("public/login", {
-        title: "Login",
-        error: "Invalid credentials",
-        old: { email },
-        remember: Boolean(remember),
-      });
-    }
-
-    const match = await bcrypt.compare(password, user.passwordHash);
-    if (!match) {
-      return res.status(401).render("public/login", {
-        title: "Login",
-        error: "Invalid credentials",
-        old: { email },
-        remember: Boolean(remember),
-      });
-    }
-
-    req.session.userId = user._id;
-
+    const decoded = await verifyIdToken(idToken);
     const rememberMe = remember === "1" || remember === "on" || remember === true;
-    req.session.cookie.maxAge = rememberMe ? THIRTY_DAYS_MS : ONE_DAY_MS;
+    const usernameHint = decoded.name || (decoded.email ? decoded.email.split("@")[0] : null);
 
-    // ✅ Ensure the session is saved before redirect
-    req.session.save((err) => {
-      if (err) {
-        console.error("Session save error:", err);
-        return res.status(500).render("public/login", {
-          title: "Login",
-          error: "Server error",
-          old: { email },
-          remember: Boolean(remember),
-        });
-      }
-      res.redirect("/u/library");
+    const user = await attachFirebaseUid({
+      firebaseUid: decoded.uid,
+      email: decoded.email,
+      usernameHint,
     });
-  } catch (err) {
-    console.error(err);
-    res.status(500).render("public/login", {
-      title: "Login",
-      error: "Server error",
-      old: { email },
-      remember: Boolean(remember),
-    });
+
+    await persistSession(req, { userId: user._id, remember: rememberMe });
+    res.json({ redirect: "/u/library" });
+  } catch (error) {
+    console.error("Login error:", error);
+    const status = error.status || 500;
+    res.status(status).json({ error: error.message || "Unable to log in." });
   }
 };
 
@@ -110,7 +197,7 @@ exports.logout = (req, res) => {
       console.error(err);
       return res.status(500).send("Logout failed");
     }
-    res.clearCookie("connect.sid"); // default session cookie name
+    res.clearCookie("connect.sid");
     res.redirect("/");
   });
 };

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -4,7 +4,8 @@ const userSchema = new mongoose.Schema(
   {
     username: { type: String, required: true, unique: true },
     email: { type: String, required: true, unique: true },
-    passwordHash: { type: String, required: true },
+    passwordHash: { type: String },
+    firebaseUid: { type: String, unique: true, sparse: true },
     role: { type: String, enum: ["user", "admin"], default: "user" },
 
     // Track story progress

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "express": "^5.1.0",
     "express-rate-limit": "^8.1.0",
     "express-session": "^1.18.2",
+    "firebase-admin": "^12.7.0",
     "mongodb": "^6.20.0",
     "mongoose": "^8.18.2",
     "multer": "^2.0.2",

--- a/public/js/about-animations.js
+++ b/public/js/about-animations.js
@@ -1,0 +1,89 @@
+const createAmbientParticles = (container, total = 24) => {
+  if (!container) return;
+
+  const fragment = document.createDocumentFragment();
+  for (let index = 0; index < total; index += 1) {
+    const particle = document.createElement('span');
+    particle.className = 'ambient-particle';
+    particle.style.left = `${Math.random() * 100}%`;
+    particle.style.top = `${Math.random() * 100}%`;
+    const scale = 0.6 + Math.random();
+    particle.style.transform = `scale(${scale})`;
+    particle.style.animationDelay = `${Math.random() * 10}s`;
+    fragment.appendChild(particle);
+  }
+
+  container.appendChild(fragment);
+};
+
+const registerMotionObserver = () => {
+  const elements = document.querySelectorAll('[data-motion]');
+  if (!elements.length) return;
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('motion-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    {
+      threshold: 0.2,
+      rootMargin: '0px 0px -10% 0px',
+    },
+  );
+
+  elements.forEach((element) => observer.observe(element));
+};
+
+const registerParallax = () => {
+  const overlay = document.querySelector('.about-hero .hero-atmosphere');
+  if (!overlay) return;
+
+  const handleScroll = () => {
+    const y = window.scrollY || window.pageYOffset;
+    overlay.style.transform = `translateY(${y * 0.06}px)`;
+  };
+
+  handleScroll();
+  window.addEventListener('scroll', handleScroll, { passive: true });
+};
+
+const registerGsapSequences = () => {
+  if (typeof window.gsap === 'undefined') return;
+  const heroContent = document.querySelector('.about-hero__content');
+  if (heroContent) {
+    window.gsap.fromTo(
+      heroContent,
+      { opacity: 0, y: 40 },
+      { opacity: 1, y: 0, duration: 1.4, ease: 'power3.out', delay: 0.2 },
+    );
+  }
+
+  window.gsap.utils.toArray('.about-visual').forEach((panel, index) => {
+    window.gsap.to(panel, {
+      yPercent: 4,
+      duration: 12,
+      yoyo: true,
+      repeat: -1,
+      ease: 'sine.inOut',
+      delay: index * 1.2,
+    });
+  });
+};
+
+const init = () => {
+  const ambientContainer = document.querySelector('.about-page .ambient-particles');
+  createAmbientParticles(ambientContainer, 36);
+  registerMotionObserver();
+  registerParallax();
+  registerGsapSequences();
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/public/js/firebase-auth.js
+++ b/public/js/firebase-auth.js
@@ -1,0 +1,284 @@
+import {
+  initializeApp,
+  getApps,
+  getApp,
+} from "https://www.gstatic.com/firebasejs/11.0.1/firebase-app.js";
+import {
+  browserLocalPersistence,
+  browserSessionPersistence,
+  createUserWithEmailAndPassword,
+  getAuth,
+  GoogleAuthProvider,
+  onAuthStateChanged,
+  sendEmailVerification,
+  sendPasswordResetEmail,
+  setPersistence,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+  signOut,
+  updateProfile,
+} from "https://www.gstatic.com/firebasejs/11.0.1/firebase-auth.js";
+
+const page = window.firebaseAuthPage || {};
+const errorBanner = document.querySelector('[data-auth-message="error"]');
+const successBanner = document.querySelector('[data-auth-message="success"]');
+
+const setBanner = (banner, message) => {
+  if (!banner) return;
+  if (!message) {
+    banner.hidden = true;
+    banner.textContent = "";
+    return;
+  }
+  banner.hidden = false;
+  banner.textContent = message;
+};
+
+const showError = (message) => setBanner(errorBanner, message);
+const showSuccess = (message) => setBanner(successBanner, message);
+const clearBanners = () => {
+  setBanner(errorBanner, "");
+  setBanner(successBanner, "");
+};
+
+const setFormDisabled = (form, disabled) => {
+  if (!form) return;
+  [...form.querySelectorAll("input, button, select")].forEach((el) => {
+    if (disabled) {
+      el.setAttribute("disabled", "disabled");
+    } else {
+      el.removeAttribute("disabled");
+    }
+  });
+};
+
+const ERROR_MESSAGES = {
+  "auth/email-already-in-use": "An account with that email already exists.",
+  "auth/invalid-email": "Please enter a valid email address.",
+  "auth/invalid-login-credentials": "Invalid email or password.",
+  "auth/user-not-found": "No account found with that email.",
+  "auth/wrong-password": "Invalid email or password.",
+  "auth/popup-closed-by-user": "The sign-in popup was closed before completing.",
+  "auth/too-many-requests": "Too many attempts. Please wait a moment and try again.",
+};
+
+const handleAuthError = (error) => {
+  console.error(error);
+  if (error && ERROR_MESSAGES[error.code]) {
+    showError(ERROR_MESSAGES[error.code]);
+    return;
+  }
+  if (error && ERROR_MESSAGES[error.message]) {
+    showError(ERROR_MESSAGES[error.message]);
+    return;
+  }
+  showError(error?.message || "Something went wrong. Please try again.");
+};
+
+const postJson = async (url, payload) => {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const error = new Error(data.error || "Request failed");
+    error.status = response.status;
+    throw error;
+  }
+  return data;
+};
+
+const establishSession = async ({ endpoint, user, payload }) => {
+  const idToken = await user.getIdToken(true);
+  const response = await postJson(endpoint, { idToken, ...payload });
+  if (response.redirect) {
+    window.location.assign(response.redirect);
+  } else if (response.message) {
+    showSuccess(response.message);
+  }
+};
+
+const loginForm = document.querySelector('[data-auth-form="login"]');
+const signupForm = document.querySelector('[data-auth-form="signup"]');
+
+const config = page.config || {};
+if (!config.apiKey) {
+  console.warn("Firebase config missing; authentication helpers are disabled.");
+} else {
+  const app = getApps().length ? getApp() : initializeApp(config);
+  const auth = getAuth(app);
+
+  const rememberInput = loginForm?.querySelector('input[name="remember"]');
+
+  const resolveRememberChoice = () => {
+    if (!rememberInput) return true;
+    return rememberInput.checked;
+  };
+
+  if (loginForm) {
+    loginForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      clearBanners();
+
+      const formData = new FormData(loginForm);
+      const email = String(formData.get("email") || "").trim();
+      const password = String(formData.get("password") || "");
+      const remember = resolveRememberChoice();
+
+      if (!email || !password) {
+        showError("Please enter your email and password.");
+        return;
+      }
+
+      setFormDisabled(loginForm, true);
+      try {
+        await setPersistence(
+          auth,
+          remember ? browserLocalPersistence : browserSessionPersistence
+        );
+        const credential = await signInWithEmailAndPassword(auth, email, password);
+        await establishSession({
+          endpoint: "/login",
+          user: credential.user,
+          payload: { remember },
+        });
+      } catch (error) {
+        handleAuthError(error);
+      } finally {
+        setFormDisabled(loginForm, false);
+      }
+    });
+
+    const googleButton = document.querySelector("[data-google-sign-in]");
+    if (googleButton) {
+      googleButton.addEventListener("click", async () => {
+        clearBanners();
+        const remember = resolveRememberChoice();
+        setFormDisabled(loginForm, true);
+        try {
+          await setPersistence(
+            auth,
+            remember ? browserLocalPersistence : browserSessionPersistence
+          );
+          const provider = new GoogleAuthProvider();
+          const credential = await signInWithPopup(auth, provider);
+          await establishSession({
+            endpoint: "/login",
+            user: credential.user,
+            payload: { remember },
+          });
+        } catch (error) {
+          handleAuthError(error);
+        } finally {
+          setFormDisabled(loginForm, false);
+        }
+      });
+    }
+
+    const resetLink = document.querySelector("[data-reset-password]");
+    if (resetLink) {
+      resetLink.addEventListener("click", async (event) => {
+        event.preventDefault();
+        clearBanners();
+        const email = loginForm.querySelector('input[name="email"]').value.trim();
+        if (!email) {
+          showError("Enter your email above and try again.");
+          return;
+        }
+        try {
+          await sendPasswordResetEmail(auth, email);
+          showSuccess("Password reset email sent! Check your inbox.");
+        } catch (error) {
+          handleAuthError(error);
+        }
+      });
+    }
+  }
+
+  if (signupForm) {
+    signupForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      clearBanners();
+
+      const formData = new FormData(signupForm);
+      const username = String(formData.get("username") || "").trim();
+      const email = String(formData.get("email") || "").trim();
+      const password = String(formData.get("password") || "");
+
+      if (!username || username.length < 3) {
+        showError("Choose a username with at least 3 characters.");
+        return;
+      }
+      if (!email || !password) {
+        showError("Email and password are required.");
+        return;
+      }
+
+      setFormDisabled(signupForm, true);
+      let credential;
+      try {
+        await setPersistence(auth, browserLocalPersistence);
+        credential = await createUserWithEmailAndPassword(auth, email, password);
+        if (username) {
+          await updateProfile(credential.user, { displayName: username });
+        }
+        try {
+          await sendEmailVerification(credential.user);
+          showSuccess("Verification email sent. Please check your inbox.");
+        } catch (error) {
+          console.warn("Email verification failed", error);
+        }
+
+        await establishSession({
+          endpoint: "/signup",
+          user: credential.user,
+          payload: { username },
+        });
+      } catch (error) {
+        if (error.status && credential?.user) {
+          try {
+            await credential.user.delete();
+          } catch (cleanupError) {
+            console.warn(
+              "Unable to delete Firebase user after signup failure",
+              cleanupError
+            );
+          }
+        }
+        await signOut(auth).catch(() => undefined);
+        handleAuthError(error);
+      } finally {
+        setFormDisabled(signupForm, false);
+      }
+    });
+  }
+
+  let handshakeComplete = false;
+
+  onAuthStateChanged(auth, async (user) => {
+    if (!user || handshakeComplete) {
+      return;
+    }
+    if (page.mode !== "login") {
+      return;
+    }
+    try {
+      handshakeComplete = true;
+      await establishSession({
+        endpoint: "/login",
+        user,
+        payload: { remember: true },
+      });
+    } catch (error) {
+      handshakeComplete = false;
+      if (error.status === 401) {
+        await signOut(auth).catch(() => undefined);
+      } else {
+        console.warn("Automatic session sync failed", error);
+      }
+    }
+  });
+}

--- a/public/js/home-animations.js
+++ b/public/js/home-animations.js
@@ -1,0 +1,105 @@
+const createAmbientParticles = (container, total = 30) => {
+  if (!container) return;
+
+  const fragment = document.createDocumentFragment();
+  for (let i = 0; i < total; i += 1) {
+    const particle = document.createElement('span');
+    particle.style.left = `${Math.random() * 100}%`;
+    particle.style.top = `${Math.random() * 100}%`;
+    const scale = 0.6 + Math.random() * 1.2;
+    particle.style.transform = `scale(${scale})`;
+    particle.style.animationDelay = `${Math.random() * 12}s`;
+    fragment.appendChild(particle);
+  }
+
+  container.appendChild(fragment);
+};
+
+const registerMotionObserver = () => {
+  const elements = document.querySelectorAll('[data-motion]');
+  if (!elements.length) return;
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('motion-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    {
+      threshold: 0.2,
+      rootMargin: '0px 0px -10% 0px',
+    },
+  );
+
+  elements.forEach((element) => observer.observe(element));
+};
+
+const registerParallax = () => {
+  const atmosphere = document.querySelector('.hero-atmosphere');
+  if (!atmosphere) return;
+
+  const handleScroll = () => {
+    const y = window.scrollY || window.pageYOffset;
+    atmosphere.style.transform = `translateY(${y * 0.08}px)`;
+  };
+
+  handleScroll();
+  window.addEventListener('scroll', handleScroll, { passive: true });
+};
+
+const registerCarousel = () => {
+  const track = document.querySelector('.story-carousel-track');
+  if (!track) return;
+
+  const scrollByCard = (direction) => {
+    const card = track.querySelector('.story-card');
+    const amount = card ? card.getBoundingClientRect().width + 24 : 320;
+    track.scrollBy({ left: direction * amount, behavior: 'smooth' });
+  };
+
+  document.querySelectorAll('[data-carousel="prev"]').forEach((button) => {
+    button.addEventListener('click', () => scrollByCard(-1));
+  });
+
+  document.querySelectorAll('[data-carousel="next"]').forEach((button) => {
+    button.addEventListener('click', () => scrollByCard(1));
+  });
+};
+
+const registerGsapSequences = () => {
+  if (typeof window.gsap === 'undefined') return;
+  const hero = document.querySelector('.home-hero');
+  if (!hero) return;
+
+  window.gsap.fromTo(
+    hero.querySelector('.hero-content'),
+    { opacity: 0, y: 40 },
+    { opacity: 1, y: 0, duration: 1.6, ease: 'power3.out', delay: 0.2 },
+  );
+
+  window.gsap.to('.hero-lantern-stream', {
+    yPercent: 6,
+    duration: 18,
+    yoyo: true,
+    repeat: -1,
+    ease: 'sine.inOut',
+  });
+};
+
+const init = () => {
+  const ambientContainer = document.querySelector('.ambient-particles');
+  createAmbientParticles(ambientContainer, 40);
+  registerMotionObserver();
+  registerParallax();
+  registerCarousel();
+  registerGsapSequences();
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -1542,3 +1542,210 @@ nav a:hover {
     font-size: 0.8rem;
   }
 }
+
+/* About Page Redesign */
+.about-body {
+  background: radial-gradient(circle at 15% 20%, rgba(91, 33, 182, 0.32), transparent 48%),
+    radial-gradient(circle at 85% 15%, rgba(14, 116, 144, 0.28), transparent 52%),
+    radial-gradient(circle at 50% 85%, rgba(180, 83, 9, 0.18), transparent 58%),
+    linear-gradient(180deg, var(--bg-dark) 0%, var(--bg-deeper) 100%);
+  color: var(--text-light);
+}
+
+.about-page {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3rem, 6vw, 6rem);
+  padding: clamp(2.5rem, 6vw, 5rem) clamp(1.5rem, 6vw, 5rem) clamp(4rem, 10vw, 7rem);
+  overflow: hidden;
+}
+
+.about-hero {
+  position: relative;
+  min-height: clamp(28rem, 75vh, 44rem);
+  padding: clamp(2rem, 4vw, 4rem);
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  border-radius: 32px;
+  overflow: hidden;
+  background: rgba(10, 10, 24, 0.72);
+  border: 1px solid rgba(103, 78, 167, 0.22);
+  box-shadow: var(--shadow-soft), var(--shadow-glow);
+}
+
+.about-hero__content {
+  max-width: 640px;
+  text-align: center;
+  gap: 1.5rem;
+}
+
+.about-hero__content h1 {
+  font-family: "Cinzel", serif;
+  font-size: clamp(2.75rem, 6vw, 4.25rem);
+  line-height: 1.1;
+  margin: 0;
+}
+
+.about-hero__content .lead {
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: var(--text-muted);
+}
+
+.about-section {
+  position: relative;
+  display: flex;
+  gap: clamp(2rem, 4vw, 3.5rem);
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+
+.about-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(2rem, 4vw, 3.5rem);
+  width: 100%;
+}
+
+.about-copy,
+.about-visual {
+  padding: clamp(2rem, 4vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.about-copy h2 {
+  font-family: "Cinzel", serif;
+  font-size: clamp(1.9rem, 4vw, 2.6rem);
+  margin: 0;
+}
+
+.about-copy p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: var(--text-muted);
+}
+
+.about-copy .cta-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.about-visual {
+  position: relative;
+  align-items: center;
+  min-height: 18rem;
+}
+
+.about-visual .image-placeholder {
+  width: 100%;
+  min-height: 220px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border: 1px dashed rgba(160, 130, 255, 0.4);
+  border-radius: 20px;
+  background: rgba(17, 12, 40, 0.55);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.about-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.about-list li {
+  position: relative;
+  padding-left: 1.5rem;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.about-list li::before {
+  content: "✦";
+  position: absolute;
+  left: 0;
+  top: 0.1rem;
+  color: rgba(251, 191, 36, 0.8);
+}
+
+.about-collab {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.collab-links {
+  display: grid;
+  gap: 1rem;
+}
+
+.collab-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.25rem;
+  border-radius: 16px;
+  background: rgba(40, 24, 64, 0.55);
+  border: 1px solid rgba(120, 92, 196, 0.3);
+  color: var(--text-light);
+  text-decoration: none;
+  transition: border-color 0.3s ease, transform 0.3s ease;
+}
+
+.collab-link:hover,
+.collab-link:focus-visible {
+  border-color: rgba(236, 196, 94, 0.65);
+  transform: translateY(-2px);
+}
+
+@media (max-width: 960px) {
+  .about-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .about-visual {
+    min-height: 16rem;
+  }
+
+  .about-copy,
+  .about-visual {
+    align-items: center;
+    text-align: center;
+  }
+
+  .about-copy .cta-buttons {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .about-page {
+    padding: 2rem 1.25rem 3.5rem;
+  }
+
+  .about-hero {
+    padding: 2rem 1.5rem;
+  }
+
+  .about-hero__content {
+    gap: 1.25rem;
+  }
+
+  .collab-link {
+    justify-content: center;
+  }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -520,6 +520,61 @@ nav a:hover {
   height: 1px;
   background: #333;
 }
+
+.google-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: #ffffff;
+  color: #101828;
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
+}
+
+.google-button:hover {
+  transform: translateY(-1px);
+  background: #f8fafc;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.3);
+}
+
+.google-button:active {
+  transform: translateY(0);
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.24);
+}
+
+.google-button:focus-visible {
+  outline: 3px solid rgba(66, 133, 244, 0.45);
+  outline-offset: 2px;
+}
+
+.google-button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 0 0 1px rgba(60, 64, 67, 0.3);
+}
+
+.google-button__icon svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.google-button__label {
+  white-space: nowrap;
+}
 .link {
   color: var(--text-light);
   text-decoration: underline;

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,12 +1,28 @@
 :root {
-  --bg-dark: #0e0e0e;
-  --text-light: #f5f5f5;
+  --bg-dark: #05030d;
+  --bg-deeper: #020109;
+  --bg-panel: rgba(18, 14, 40, 0.65);
+  --bg-panel-strong: rgba(35, 23, 62, 0.8);
+  --bg-glow: linear-gradient(135deg, rgba(90, 47, 255, 0.45), rgba(0, 159, 227, 0.35));
+  --text-light: #f5f4ff;
+  --text-muted: rgba(226, 220, 255, 0.74);
   --accent-red: #b22222;
-  --accent-purple: #5d3fd3;
+  --accent-purple: #7d55ff;
   --accent-blue: #2563eb;
   --accent-blue-dark: #1d4ed8;
   --accent-blue-darker: #1e3a8a;
-  --muted-gray: #2c2c2c;
+  --accent-indigo: #4338ca;
+  --accent-gold: #d4b66b;
+  --accent-teal: #2dd4bf;
+  --muted-gray: rgba(255, 255, 255, 0.04);
+  --border-light: rgba(255, 255, 255, 0.14);
+  --shadow-soft: 0 20px 45px rgba(0, 0, 0, 0.45);
+  --shadow-glow: 0 0 60px rgba(101, 78, 255, 0.3);
+  --transition-snappy: 220ms ease;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {
@@ -17,21 +33,26 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
 }
 
-header {
+.site-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 1rem 2rem;
-  background: var(--muted-gray);
+  background: rgba(10, 8, 24, 0.7);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
 }
 
-header h1 {
+.site-header h1 {
   font-family: "Cinzel", serif;
   font-size: 1.5rem;
   margin: 0;
-  color: var(--accent-red);
+  color: var(--accent-gold);
+  letter-spacing: 0.08em;
 }
 
 .menu-toggle {
@@ -110,7 +131,7 @@ nav a:hover {
 }
 
 @media (max-width: 800px) {
-  header {
+  .site-header {
     flex-wrap: wrap;
     row-gap: 0.75rem;
   }
@@ -969,4 +990,555 @@ nav a:hover {
   font-size: 20px;
   line-height: 1;
   cursor: pointer;
+}
+
+.home-body {
+  background: radial-gradient(circle at 20% 20%, rgba(93, 63, 211, 0.35), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(29, 78, 216, 0.3), transparent 50%),
+    radial-gradient(circle at 50% 90%, rgba(180, 109, 255, 0.25), transparent 55%),
+    linear-gradient(180deg, var(--bg-dark) 0%, var(--bg-deeper) 100%);
+}
+
+.home-page {
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3rem, 8vw, 7rem);
+  padding: clamp(2.5rem, 6vw, 6rem) clamp(1.5rem, 6vw, 5rem) clamp(4rem, 10vw, 8rem);
+  overflow: hidden;
+}
+
+.ambient-particles {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.ambient-particles span {
+  position: absolute;
+  display: block;
+  width: 8px;
+  height: 8px;
+  background: radial-gradient(circle, rgba(247, 244, 255, 0.9), rgba(125, 85, 255, 0));
+  box-shadow: 0 0 12px rgba(125, 85, 255, 0.6);
+  border-radius: 999px;
+  animation: floatY 12s ease-in-out infinite;
+}
+
+.glass-panel {
+  background: var(--bg-panel);
+  backdrop-filter: blur(18px);
+  border: 1px solid var(--border-light);
+  border-radius: 24px;
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  z-index: 1;
+}
+
+.home-hero {
+  position: relative;
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  min-height: clamp(32rem, 80vh, 48rem);
+  padding: clamp(2rem, 4vw, 4rem);
+  border-radius: 32px;
+  overflow: hidden;
+  background: rgba(8, 5, 20, 0.75);
+  border: 1px solid rgba(125, 85, 255, 0.18);
+  box-shadow: var(--shadow-soft), var(--shadow-glow);
+}
+
+.hero-atmosphere {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.hero-fog-layer,
+.hero-lantern-stream {
+  position: absolute;
+  inset: -30%;
+  background: radial-gradient(circle, rgba(130, 107, 255, 0.18), transparent 65%);
+  opacity: 0.4;
+  filter: blur(80px);
+  animation: drift 30s linear infinite;
+}
+
+.hero-lantern-stream {
+  animation-duration: 45s;
+  mix-blend-mode: screen;
+}
+
+.hero-overlay-image {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: clamp(2rem, 4vw, 5rem);
+  pointer-events: none;
+}
+
+.overlay-placeholder {
+  display: inline-flex;
+  padding: 1.25rem 1.5rem;
+  background: rgba(11, 8, 25, 0.65);
+  border: 1px dashed rgba(173, 139, 255, 0.5);
+  border-radius: 18px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-align: center;
+  max-width: 420px;
+  backdrop-filter: blur(14px);
+}
+
+.hero-content {
+  max-width: 620px;
+  padding: clamp(2rem, 4vw, 3.5rem);
+  text-align: center;
+}
+
+.hero-content .eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  color: var(--accent-teal);
+  font-size: 0.8rem;
+  margin-bottom: 1.5rem;
+}
+
+.hero-content h2 {
+  font-family: "Cinzel", serif;
+  font-size: clamp(2.75rem, 7vw, 4.5rem);
+  line-height: 1.1;
+  margin: 0 0 1.5rem;
+}
+
+.hero-subtext {
+  margin: 0 auto 2.5rem;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--text-muted);
+}
+
+.hero-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 0.85rem 1.95rem;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy),
+    background var(--transition-snappy), color var(--transition-snappy);
+  border: 1px solid transparent;
+  backdrop-filter: blur(8px);
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, rgba(138, 92, 255, 0.85), rgba(41, 180, 255, 0.75));
+  box-shadow: 0 10px 35px rgba(112, 86, 255, 0.45);
+  color: white;
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 15px 45px rgba(112, 86, 255, 0.6);
+}
+
+.btn-secondary {
+  background: rgba(16, 12, 36, 0.7);
+  color: var(--accent-gold);
+  border-color: rgba(212, 182, 107, 0.35);
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus-visible {
+  color: white;
+  background: rgba(41, 28, 80, 0.9);
+}
+
+.btn-ghost {
+  background: rgba(10, 8, 24, 0.45);
+  color: var(--text-muted);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus-visible {
+  color: white;
+  background: rgba(41, 34, 76, 0.75);
+}
+
+.hero-scroll-hint {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 0.5em;
+  text-transform: uppercase;
+}
+
+.scroll-line {
+  width: 1px;
+  height: 50px;
+  margin-top: 0.75rem;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.4), transparent);
+  animation: scrollPulse 2.8s ease-in-out infinite;
+}
+
+.section-title {
+  font-family: "Cinzel", serif;
+  font-size: clamp(1.8rem, 3vw, 2.5rem);
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.section-subtext {
+  color: var(--text-muted);
+  max-width: 720px;
+  margin: 0 auto 2.5rem;
+  text-align: center;
+  line-height: 1.7;
+}
+
+.feature-highlights .feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.75rem;
+  position: relative;
+  z-index: 1;
+}
+
+.feature-card {
+  padding: 2.25rem 1.75rem;
+  text-align: center;
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy);
+}
+
+.feature-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-soft), 0 0 45px rgba(124, 86, 255, 0.25);
+}
+
+.feature-icon {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.feature-card p {
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.earn-section {
+  position: relative;
+}
+
+.section-header {
+  text-align: center;
+}
+
+.earn-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.earn-card {
+  padding: 2rem 1.75rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  text-align: center;
+}
+
+.image-placeholder {
+  padding: 1.75rem 1.25rem;
+  border-radius: 18px;
+  border: 1px dashed rgba(152, 122, 255, 0.45);
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  background: rgba(8, 5, 22, 0.55);
+}
+
+.builder-showcase {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: center;
+}
+
+.showcase-text {
+  padding: clamp(2rem, 4vw, 3.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.showcase-text p {
+  color: var(--text-muted);
+  line-height: 1.7;
+}
+
+.showcase-visual {
+  position: relative;
+  padding: 2rem;
+  min-height: 260px;
+}
+
+.node-pulse {
+  position: absolute;
+  inset: 15%;
+  border-radius: 24px;
+  background: radial-gradient(circle at 20% 30%, rgba(118, 99, 255, 0.6), transparent 55%),
+    radial-gradient(circle at 80% 70%, rgba(47, 209, 231, 0.45), transparent 60%);
+  filter: blur(35px);
+  animation: pulseGlow 6s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.library-community .story-carousel {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.story-carousel-track {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(240px, 1fr);
+  gap: 1.5rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  padding: 1rem 0;
+}
+
+.story-carousel-track::-webkit-scrollbar {
+  height: 6px;
+}
+
+.story-carousel-track::-webkit-scrollbar-thumb {
+  background: rgba(135, 110, 255, 0.5);
+  border-radius: 999px;
+}
+
+.story-card {
+  position: relative;
+  padding: 1.75rem;
+  min-height: 200px;
+  scroll-snap-align: start;
+  overflow: hidden;
+  transition: transform var(--transition-snappy), box-shadow var(--transition-snappy);
+}
+
+.story-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-soft), 0 0 45px rgba(93, 63, 211, 0.3);
+}
+
+.story-card.locked {
+  border: 1px solid rgba(247, 196, 109, 0.35);
+}
+
+.lock-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(13, 10, 28, 0.82);
+  backdrop-filter: blur(6px);
+  color: var(--accent-gold);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.carousel-control {
+  background: rgba(15, 11, 32, 0.7);
+  border: 1px solid rgba(156, 125, 255, 0.35);
+  color: white;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform var(--transition-snappy), background var(--transition-snappy);
+}
+
+.carousel-control:hover,
+.carousel-control:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(47, 34, 97, 0.9);
+}
+
+.tech-stack {
+  padding: clamp(3rem, 5vw, 4.5rem);
+  border-radius: 28px;
+  text-align: center;
+  background: linear-gradient(160deg, rgba(15, 11, 34, 0.85), rgba(38, 25, 72, 0.85));
+  border: 1px solid rgba(142, 113, 255, 0.2);
+  box-shadow: var(--shadow-soft);
+}
+
+.tech-orbs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.25rem;
+  margin-top: 2rem;
+}
+
+.tech-orbs span {
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: rgba(33, 22, 69, 0.75);
+  border: 1px solid rgba(121, 98, 255, 0.35);
+  color: rgba(222, 214, 255, 0.9);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.cta-section {
+  text-align: center;
+  padding: clamp(3rem, 5vw, 5rem);
+  border-radius: 32px;
+  background: radial-gradient(circle at 20% 20%, rgba(143, 103, 255, 0.25), transparent 60%),
+    radial-gradient(circle at 80% 80%, rgba(45, 209, 231, 0.2), transparent 65%),
+    rgba(9, 6, 24, 0.72);
+  border: 1px solid rgba(142, 113, 255, 0.25);
+  box-shadow: var(--shadow-soft);
+}
+
+.cta-section h3 {
+  font-family: "Cinzel", serif;
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin-bottom: 2rem;
+}
+
+.cta-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.site-footer {
+  margin-top: auto;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  background: rgba(7, 5, 18, 0.85);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  color: rgba(214, 210, 244, 0.7);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-footer a {
+  color: inherit;
+}
+
+[data-motion] {
+  opacity: 0;
+  transform: translateY(50px);
+  transition: opacity 0.9s ease, transform 0.9s ease;
+}
+
+[data-motion].motion-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@keyframes drift {
+  0% {
+    transform: translate3d(-10%, -10%, 0) scale(1.1);
+  }
+  50% {
+    transform: translate3d(8%, 6%, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(-10%, -10%, 0) scale(1.1);
+  }
+}
+
+@keyframes floatY {
+  0%,
+  100% {
+    transform: translate3d(0, -10px, 0) scale(1);
+    opacity: 0.4;
+  }
+  50% {
+    transform: translate3d(0, 20px, 0) scale(1.1);
+    opacity: 1;
+  }
+}
+
+@keyframes pulseGlow {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 0.9;
+  }
+}
+
+@keyframes scrollPulse {
+  0%,
+  100% {
+    opacity: 0.2;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(10px);
+  }
+}
+
+@media (max-width: 720px) {
+  .home-hero {
+    padding: 2.5rem 1.75rem 4.5rem;
+  }
+
+  .hero-content {
+    padding: 2rem 1.5rem;
+  }
+
+  .story-carousel-track {
+    grid-auto-columns: minmax(80%, 1fr);
+  }
+
+  .showcase-text,
+  .showcase-visual {
+    padding: 1.75rem;
+  }
+
+  .tech-orbs span {
+    font-size: 0.8rem;
+  }
 }

--- a/utils/firebaseAdmin.js
+++ b/utils/firebaseAdmin.js
@@ -1,0 +1,25 @@
+const admin = require("firebase-admin");
+
+if (!admin.apps.length) {
+  const {
+    FIREBASE_PROJECT_ID,
+    FIREBASE_CLIENT_EMAIL,
+    FIREBASE_PRIVATE_KEY,
+  } = process.env;
+
+  if (!FIREBASE_PROJECT_ID || !FIREBASE_CLIENT_EMAIL || !FIREBASE_PRIVATE_KEY) {
+    throw new Error(
+      "Missing Firebase Admin environment variables. Please set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, and FIREBASE_PRIVATE_KEY."
+    );
+  }
+
+  admin.initializeApp({
+    credential: admin.credential.cert({
+      projectId: FIREBASE_PROJECT_ID,
+      clientEmail: FIREBASE_CLIENT_EMAIL,
+      privateKey: FIREBASE_PRIVATE_KEY.replace(/\\n/g, "\n"),
+    }),
+  });
+}
+
+module.exports = admin;

--- a/utils/firebaseConfig.js
+++ b/utils/firebaseConfig.js
@@ -1,0 +1,21 @@
+const FIREBASE_CONFIG_MAP = {
+  FIREBASE_API_KEY: "apiKey",
+  FIREBASE_AUTH_DOMAIN: "authDomain",
+  FIREBASE_PROJECT_ID: "projectId",
+  FIREBASE_STORAGE_BUCKET: "storageBucket",
+  FIREBASE_MESSAGING_SENDER_ID: "messagingSenderId",
+  FIREBASE_APP_ID: "appId",
+  FIREBASE_MEASUREMENT_ID: "measurementId",
+};
+
+const buildFirebaseConfig = () => {
+  const config = {};
+  Object.entries(FIREBASE_CONFIG_MAP).forEach(([envKey, configKey]) => {
+    if (process.env[envKey]) {
+      config[configKey] = process.env[envKey];
+    }
+  });
+  return config;
+};
+
+module.exports = { buildFirebaseConfig };

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,3 +1,3 @@
 <footer class="site-footer">
-  <p>© 2025 Shadow Paths | Created by Alexander Green</p>
+  <p>© 2025 Shadow Paths | Created by Alexander Green — Full-Stack Developer &amp; Storyteller</p>
 </footer>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,9 +1,3 @@
 <footer class="site-footer">
-  <p>
-    &copy; <%= new Date().getFullYear() %> Shadow Paths | A
-    Choose-Your-Own-Adventure Experience
-  </p>
-  <p>
-    Alexander Green | <a href="/contact">Contact</a> | Tooele Technical College
-  </p>
+  <p>© 2025 Shadow Paths | Created by Alexander Green</p>
 </footer>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -55,3 +55,41 @@
     });
   })();
 </script>
+<% if (firebaseConfig && firebaseConfig.apiKey) { %>
+<script type="module">
+  import {
+    initializeApp,
+    getApps,
+    getApp,
+  } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-app.js";
+  import { getAuth, signOut } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-auth.js";
+
+  const config = <%- JSON.stringify(firebaseConfig) %>;
+  if (config.apiKey) {
+    const app = getApps().length ? getApp() : initializeApp(config);
+    const auth = getAuth(app);
+
+    document.querySelectorAll("form.logout-form").forEach((form) => {
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        try {
+          await signOut(auth);
+        } catch (error) {
+          console.warn("Firebase sign-out failed", error);
+        }
+
+        try {
+          await fetch(form.action || "/logout", {
+            method: "POST",
+            credentials: "same-origin",
+          });
+        } catch (error) {
+          console.warn("Logout request failed", error);
+        }
+
+        window.location.assign("/");
+      });
+    });
+  }
+</script>
+<% } %>

--- a/views/public/about.ejs
+++ b/views/public/about.ejs
@@ -3,86 +3,122 @@
   <head>
     <%- include('../partials/head') %>
   </head>
-  <body>
-    <%- include('../partials/header', { user }); %>
+  <body class="about-body">
+    <% const headerConfig = typeof firebaseConfig !== 'undefined' ? firebaseConfig : null; %>
+    <%- include('../partials/header', { user, firebaseConfig: headerConfig }); %>
 
-    <main class="container about">
-      <section class="page-hero">
-        <h1 class="title">About Shadow Paths</h1>
-        <p class="lead">
-          A clean, distraction-light platform for interactive, spooky-fantasy
-          stories. Your choices shape the path—your stats and trophies remember
-          the journey.
-        </p>
-      </section>
+    <main class="about-page" id="top">
+      <div class="ambient-particles" aria-hidden="true"></div>
 
-      <section class="grid two-col">
-        <div>
-          <h2>What is this?</h2>
-          <p>
-            <strong>Shadow Paths</strong> is a choose-your-own-adventure site
-            with a DnD-inspired vibe. Stories are built as branching nodes, so
-            every decision can unlock new scenes, endings, and achievements.
-          </p>
-
-          <h3>Key Features</h3>
-          <ul>
-            <li>
-              <strong>Interactive Library:</strong> Browse story cards by genre
-              and difficulty.
-            </li>
-            <li>
-              <strong>Auto-Save:</strong> Your progress sticks—pick up right
-              where you left off.
-            </li>
-            <li>
-              <strong>Player Stats:</strong> Track endings unlocked, routes
-              explored, and time played.
-            </li>
-            <li>
-              <strong>Awards:</strong> Earn badges for bold choices and rare
-              outcomes.
-            </li>
-          </ul>
+      <section class="about-hero" data-motion="fade-up">
+        <div class="hero-atmosphere" aria-hidden="true">
+          <div class="hero-fog-layer"></div>
+          <div
+            class="hero-overlay-image"
+            role="img"
+            aria-label="Lantern light drifting through a shadowed forest path."
+          >
+            <span class="overlay-placeholder">
+              Placeholder — Prompt: “Transparent PNG of a glowing lantern guiding a misty forest path, dark fantasy lighting.”
+            </span>
+          </div>
         </div>
-
-        <div>
-          <h2>For Creators</h2>
-          <p>
-            Our admin tools let you build stories visually with nodes and
-            choices, edit live content safely, and roll out updates without
-            breaking player saves.
+        <div class="about-hero__content glass-panel hero-content">
+          <p class="eyebrow">Shadow Paths</p>
+          <h1>The Story Behind the Stories</h1>
+          <p class="lead">
+            I’ve always believed every great adventure begins with a single choice.
+            Shadow Paths was born from that belief — a space where readers explore mysterious tales, and creators bring their own to life.
           </p>
-
-          <h3>Our Aesthetic</h3>
-          <p>
-            Minimal UI, concept-art illustrations (suggestive, not literal),
-            dark mode by default, and crisp typography for long reads.
-          </p>
+          <div class="hero-buttons">
+            <a class="btn btn-primary" href="/u/library">Play a Story</a>
+            <a class="btn btn-secondary" href="/u/authors">Build a Story</a>
+            <a class="btn btn-ghost" href="#collaboration">Learn More</a>
+          </div>
         </div>
       </section>
 
-      <section class="grid two-col">
-        <div>
-          <h2>Privacy & Safety</h2>
-          <ul>
-            <li>No trackers beyond what’s needed to run the site.</li>
-            <li>Passwords are hashed, sessions are secured.</li>
-            <li>You control your data: export or delete on request.</li>
-          </ul>
+      <section class="about-section about-me" data-motion="fade-up">
+        <div class="about-layout">
+          <div class="about-copy glass-panel">
+            <h2>About Alexander Green</h2>
+            <p>
+              Hi, I’m Alexander Green — a software developer, storyteller, and perpetual adventurer.
+              I love blending creativity with technology to build immersive web experiences.
+              I specialize in full-stack JavaScript development (MERN) and I’m always open to collaborations or freelance projects.
+            </p>
+            <div class="cta-buttons">
+              <a class="btn btn-primary" href="/contact">Contact Me</a>
+              <a
+                class="btn btn-secondary"
+                href="https://github.com/GreenHouse007/AdventureStory"
+                target="_blank"
+                rel="noreferrer"
+              >
+                View GitHub
+              </a>
+            </div>
+          </div>
+          <div class="about-visual glass-panel" aria-hidden="true">
+            <div class="image-placeholder">
+              <span>
+                Placeholder — Prompt: “Transparent PNG of a glowing code terminal beside an enchanted lantern, dark fantasy ambiance.”
+              </span>
+            </div>
+          </div>
         </div>
+      </section>
 
-        <div>
-          <h2>Contact & Feedback</h2>
-          <p>Found a bug, want a feature, or have a story idea?</p>
+      <section class="about-section about-shadow" data-motion="fade-up">
+        <div class="about-layout">
+          <div class="about-visual glass-panel" aria-hidden="true">
+            <div class="image-placeholder">
+              <span>
+                Placeholder — Prompt: “Collage of Shadow Paths builder grid, story library, and stats dashboard, transparent layers.”
+              </span>
+            </div>
+          </div>
+          <div class="about-copy glass-panel">
+            <h2>About Shadow Paths</h2>
+            <p>
+              Shadow Paths began as a choose-your-own-adventure experiment inspired by dark fantasy and D&amp;D.
+              It’s now a full-stack narrative engine with player stats, trophies, gems, and unlockable paths — and a grid-based story builder where creators bring their tales to life.
+            </p>
+            <ul class="about-list">
+              <li>Twine-style visual builder with real-time saving.</li>
+              <li>Player profiles that track endings, medals, and shimmering currencies.</li>
+              <li>Community libraries where adventures evolve together.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="about-section about-collab" id="collaboration" data-motion="fade-up">
+        <div class="about-copy glass-panel">
+          <h2>Collaboration &amp; Contact</h2>
           <p>
-            <a class="link" href="/contact">Send feedback</a> — we read
-            everything.
+            Whether you’re a writer, a developer, or a dreamer — let’s build something together.
           </p>
+          <div class="collab-links">
+            <a class="collab-link" href="/contact">💬 /contact</a>
+            <a class="collab-link" href="https://github.com/GreenHouse007/AdventureStory" target="_blank" rel="noreferrer">
+              💻 https://github.com/GreenHouse007/AdventureStory
+            </a>
+          </div>
+        </div>
+        <div class="about-visual glass-panel" aria-hidden="true">
+          <div class="image-placeholder">
+            <span>
+              Placeholder — Prompt: “Transparent PNG of swirling ember particles surrounding an open notebook and quill.”
+            </span>
+          </div>
         </div>
       </section>
     </main>
 
     <%- include('../partials/footer') %>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha512-ApEc/WSavwg+IpYzfsHDyH5c5jMxo/nMB7alfg7K2NuHgZIBt1WvE5wkgh0Mz6/TJPZ2iEs8M0hCWc0sYjC7iA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="/js/about-animations.js" type="module"></script>
   </body>
 </html>

--- a/views/public/home.ejs
+++ b/views/public/home.ejs
@@ -3,28 +3,191 @@
   <head>
     <%- include('../partials/head') %>
   </head>
-  <body>
-    <%- include('../partials/header', { user }); %>
+  <body class="home-body">
+    <% const headerConfig = typeof firebaseConfig !== 'undefined' ? firebaseConfig : null; %>
+    <%- include('../partials/header', { user, firebaseConfig: headerConfig }); %>
+    <main class="home-page" id="top">
+      <div class="ambient-particles" aria-hidden="true"></div>
 
-    <!--<div class="banner">
-    <img src="/images/banner.jpg" alt="Shadow Paths Banner" />
-    </div>-->
+      <section class="home-hero" data-motion="fade-up">
+        <div class="hero-atmosphere" aria-hidden="true">
+          <div class="hero-fog-layer"></div>
+          <div class="hero-lantern-stream"></div>
+          <div
+            class="hero-overlay-image"
+            role="img"
+            aria-label="Glowing lanterns mark a path through a shadowed forest."
+          >
+            <span class="overlay-placeholder">
+              Placeholder — Transparent PNG prompt:
+              “Glowing lantern-lit forest path, misty, dark fantasy, cinematic lighting, transparent background.”
+            </span>
+          </div>
+        </div>
+        <div class="hero-content glass-panel">
+          <p class="eyebrow">Shadow Paths</p>
+          <h2>Every choice leads deeper into the dark.</h2>
+          <p class="hero-subtext">
+            Shadow Paths is an interactive storytelling platform where players explore branching tales — and creators forge their own.
+          </p>
+          <div class="hero-buttons">
+            <a class="btn btn-primary" href="/u/library">Play a Story</a>
+            <a class="btn btn-secondary" href="/u/authors">Build a Story</a>
+            <a class="btn btn-ghost" href="#discover">Learn More</a>
+          </div>
+        </div>
+        <div class="hero-scroll-hint" aria-hidden="true">
+          <span>Scroll</span>
+          <div class="scroll-line"></div>
+        </div>
+      </section>
 
-    <!-- Hero -->
-    <section class="hero">
-      <h2>Every Choice Shapes Your Fate</h2>
-      <p>
-        Step into dark forests, cursed ruins, and twisted realms. Choose wisely,
-        for your path may lead to glory... or ruin.
-      </p>
-      <button class="cta-button">Begin Your Journey</button>
+      <section class="feature-highlights" id="discover" data-motion="fade-up">
+        <h3 class="section-title">Discover What Awaits</h3>
+        <div class="feature-grid">
+          <article class="feature-card glass-panel" data-motion="fade-up">
+            <div class="feature-icon">🧩</div>
+            <h4>Node Story Builder</h4>
+            <p>Craft branching adventures with an elegant Twine-style grid editor.</p>
+          </article>
+          <article class="feature-card glass-panel" data-motion="fade-up">
+            <div class="feature-icon">🌐</div>
+            <h4>Story Libraries</h4>
+            <p>Curate public, community, or private collections tailored to every traveler.</p>
+          </article>
+          <article class="feature-card glass-panel" data-motion="fade-up">
+            <div class="feature-icon">🧙</div>
+            <h4>Player Profiles</h4>
+            <p>Track endings discovered, stats earned, and medals claimed across realms.</p>
+          </article>
+          <article class="feature-card glass-panel" data-motion="fade-up">
+            <div class="feature-icon">📜</div>
+            <h4>Dynamic Choices</h4>
+            <p>Continue the journey or restart anew once the final page turns.</p>
+          </article>
+        </div>
+      </section>
 
-      <!-- Teaser Image -->
-      <div class="teaser">
-        <img src="/images/bookMagic.png" alt="Teaser Art" />
-      </div>
-    </section>
+      <section class="earn-section" data-motion="fade-up">
+        <div class="section-header">
+          <h3 class="section-title">Earn, Collect, Unlock</h3>
+          <p class="section-subtext">
+            Find secret endings, earn shimmering trophies, and gather gems to unlock new story paths.
+          </p>
+        </div>
+        <div class="earn-grid">
+          <div class="earn-card glass-panel" data-motion="fade-up">
+            <h4>Trophies</h4>
+            <div class="image-placeholder" aria-hidden="true">
+              <span>
+                Placeholder — Prompt: “Transparent PNG of bronze, silver, gold, platinum trophies glowing softly.”
+              </span>
+            </div>
+            <p>Claim luminous accolades for completing legendary feats and hidden objectives.</p>
+          </div>
+          <div class="earn-card glass-panel" data-motion="fade-up">
+            <h4>Stats</h4>
+            <div class="image-placeholder" aria-hidden="true">
+              <span>
+                Placeholder — Prompt: “Stylized mockup of Shadow Paths stats dashboard (1080p).”
+              </span>
+            </div>
+            <p>Visualize endings reached, branching choices, and time spent unraveling mysteries.</p>
+          </div>
+          <div class="earn-card glass-panel" data-motion="fade-up">
+            <h4>Gems</h4>
+            <div class="image-placeholder" aria-hidden="true">
+              <span>
+                Placeholder — Prompt: “Transparent PNG of glowing gem cluster (purple, blue, gold hues).”
+              </span>
+            </div>
+            <p>Gather ethereal gems to unlock premium chapters and shimmering side quests.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="builder-showcase" data-motion="fade-up">
+        <div class="showcase-text glass-panel">
+          <h3>Build immersive branching stories with our visual grid editor.</h3>
+          <p>
+            Lay out narrative nodes, weave shimmering connections, and preview every timeline before publishing to eager adventurers.
+          </p>
+          <a class="btn btn-secondary" href="/u/authors">Open the Builder</a>
+        </div>
+        <div class="showcase-visual glass-panel" data-motion="fade-up">
+          <div class="image-placeholder">
+            <span>
+              Placeholder — Prompt: “1920×1080 transparent PNG of glowing story nodes connected by silver lines on a dark grid.”
+            </span>
+          </div>
+          <div class="node-pulse" aria-hidden="true"></div>
+        </div>
+      </section>
+
+      <section class="library-community" data-motion="fade-up">
+        <div class="section-header">
+          <h3 class="section-title">Explore a living library of adventures created by players around the world.</h3>
+          <p class="section-subtext">
+            Discover curated collections, rotating spotlights, and community crafted sagas.
+          </p>
+        </div>
+        <div class="story-carousel">
+          <button class="carousel-control" type="button" data-carousel="prev" aria-label="Previous stories">&#10094;</button>
+          <div class="story-carousel-track" role="list">
+            <article class="story-card glass-panel" data-motion="fade-up" role="listitem">
+              <h4>Lanternfall</h4>
+              <p>Navigate mist-cloaked ruins where every lantern hides a riddle.</p>
+            </article>
+            <article class="story-card glass-panel" data-motion="fade-up" role="listitem">
+              <h4>Echoes in the Vale</h4>
+              <p>Unearth ancestral whispers guiding you through branching destinies.</p>
+            </article>
+            <article class="story-card glass-panel" data-motion="fade-up" role="listitem">
+              <h4>Keeper of Cinders</h4>
+              <p>Balance embers of power before the final flame fades to black.</p>
+            </article>
+            <article class="story-card glass-panel locked" data-motion="fade-up" role="listitem">
+              <div class="lock-overlay">
+                <span>Requires 10 Gems</span>
+              </div>
+              <h4>Secrets of the Obsidian Tome</h4>
+              <p>Awaiting the worthy — unlock this saga with gathered gems.</p>
+              <div class="image-placeholder" aria-hidden="true">
+                <span>
+                  Placeholder — Prompt: “Transparent PNG of a glowing storybook with a lock symbol.”
+                </span>
+              </div>
+            </article>
+          </div>
+          <button class="carousel-control" type="button" data-carousel="next" aria-label="Next stories">&#10095;</button>
+        </div>
+      </section>
+
+      <section class="tech-stack" data-motion="fade-up">
+        <h3 class="section-title">Built with Node.js · Express · MongoDB · Firebase Auth · Cloudinary · Resend API</h3>
+        <div class="tech-orbs" aria-hidden="true">
+          <span>Node.js</span>
+          <span>Express</span>
+          <span>MongoDB</span>
+          <span>Firebase</span>
+          <span>Cloudinary</span>
+          <span>Resend</span>
+        </div>
+      </section>
+
+      <section class="cta-section" data-motion="fade-up">
+        <h3>Your story begins here. Will you read… or will you write?</h3>
+        <div class="cta-buttons">
+          <a class="btn btn-primary" href="/u/library">Play a Story</a>
+          <a class="btn btn-secondary" href="/u/authors">Create Your Own</a>
+          <a class="btn btn-ghost" href="https://github.com/GreenHouse007/AdventureStory" target="_blank" rel="noreferrer">View GitHub</a>
+        </div>
+      </section>
+    </main>
 
     <%- include('../partials/footer') %>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js" integrity="sha512-ApEc/WSavwg+IpYzfsHDyH5c5jMxo/nMB7alfg7K2NuHgZIBt1WvE5wkgh0Mz6/TJPZ2iEs8M0hCWc0sYjC7iA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="/js/home-animations.js" type="module"></script>
   </body>
 </html>

--- a/views/public/login.ejs
+++ b/views/public/login.ejs
@@ -76,8 +76,16 @@
         </div>
 
         <div class="divider" aria-hidden="true"><span>or</span></div>
-        <button class="button ghost" type="button" data-google-sign-in>
-          Continue with Google
+        <button class="google-button" type="button" data-google-sign-in>
+          <span class="google-button__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+              <path fill="#EA4335" d="M12 10.2v3.9h5.46c-.24 1.26-.98 2.33-2.1 3.06l3.39 2.64C20.34 17.76 21.5 15.11 21.5 12c0-.75-.07-1.47-.21-2.16H12Z" />
+              <path fill="#34A853" d="M6.54 14.3a4.8 4.8 0 0 1 0-4.59L3.15 7.07A8.003 8.003 0 0 0 4 16.95l2.54-2.65Z" />
+              <path fill="#4285F4" d="M12 5.5c1.13 0 2.15.39 2.96 1.15l2.21-2.21A7.968 7.968 0 0 0 4 7.05l2.54 2.65A4.77 4.77 0 0 1 12 5.5Z" />
+              <path fill="#FBBC05" d="M12 20.5a4.76 4.76 0 0 1-5.46-3.35L4 16.95A7.97 7.97 0 0 0 12 21.5c1.93 0 3.69-.69 5.05-1.86l-3.39-2.64A4.77 4.77 0 0 1 12 20.5Z" />
+            </svg>
+          </span>
+          <span class="google-button__label">Continue with Google</span>
         </button>
       </section>
     </main>

--- a/views/public/login.ejs
+++ b/views/public/login.ejs
@@ -12,12 +12,19 @@
         <p class="muted">Log in to continue your adventure.</p>
 
         <% if (typeof error !== 'undefined' && error) { %>
-        <div class="alert error"><%= error %></div>
-        <% } %> <% if (typeof success !== 'undefined' && success) { %>
-        <div class="alert success"><%= success %></div>
+        <div class="alert error" data-auth-message="error"><%= error %></div>
+        <% } else { %>
+        <div class="alert error" data-auth-message="error" hidden></div>
         <% } %>
+        <div class="alert success" data-auth-message="success" hidden></div>
 
-        <form action="/login" method="post" class="stack" novalidate>
+        <form
+          action="/login"
+          method="post"
+          class="stack"
+          novalidate
+          data-auth-form="login"
+        >
           <!-- CSRF token if you enable it -->
           <% if (locals.csrfToken) { %>
           <input type="hidden" name="_csrf" value="<%= csrfToken %>" />
@@ -61,18 +68,27 @@
         </form>
 
         <div class="auth-links">
-          <a class="link" href="/forgot-password">Forgot password?</a>
+          <a class="link" href="/forgot-password" data-reset-password
+            >Forgot password?</a
+          >
           <span>·</span>
           <a class="link" href="/signup">Create an account</a>
         </div>
 
-        <!-- Optional: Social logins (hide until wired up) -->
-        <!--
-      <div class="divider"><span>or</span></div>
-      <a class="button ghost" href="/auth/google">Continue with Google</a>
-      --></section>
+        <div class="divider" aria-hidden="true"><span>or</span></div>
+        <button class="button ghost" type="button" data-google-sign-in>
+          Continue with Google
+        </button>
+      </section>
     </main>
 
     <%- include('../partials/footer') %>
+    <script>
+      window.firebaseAuthPage = {
+        config: <%- JSON.stringify(firebaseConfig || {}) %>,
+        mode: "login",
+      };
+    </script>
+    <script type="module" src="/js/firebase-auth.js"></script>
   </body>
 </html>

--- a/views/public/signup.ejs
+++ b/views/public/signup.ejs
@@ -80,6 +80,19 @@
           <button class="cta-button" type="submit">Create Account</button>
         </form>
 
+        <div class="divider" aria-hidden="true"><span>or</span></div>
+        <button class="google-button" type="button" data-google-sign-in>
+          <span class="google-button__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" focusable="false">
+              <path fill="#EA4335" d="M12 10.2v3.9h5.46c-.24 1.26-.98 2.33-2.1 3.06l3.39 2.64C20.34 17.76 21.5 15.11 21.5 12c0-.75-.07-1.47-.21-2.16H12Z" />
+              <path fill="#34A853" d="M6.54 14.3a4.8 4.8 0 0 1 0-4.59L3.15 7.07A8.003 8.003 0 0 0 4 16.95l2.54-2.65Z" />
+              <path fill="#4285F4" d="M12 5.5c1.13 0 2.15.39 2.96 1.15l2.21-2.21A7.968 7.968 0 0 0 4 7.05l2.54 2.65A4.77 4.77 0 0 1 12 5.5Z" />
+              <path fill="#FBBC05" d="M12 20.5a4.76 4.76 0 0 1-5.46-3.35L4 16.95A7.97 7.97 0 0 0 12 21.5c1.93 0 3.69-.69 5.05-1.86l-3.39-2.64A4.77 4.77 0 0 1 12 20.5Z" />
+            </svg>
+          </span>
+          <span class="google-button__label">Sign up with Google</span>
+        </button>
+
         <div class="auth-links">
           <span>Already have an account?</span>
           <a class="link" href="/login">Log in</a>

--- a/views/public/signup.ejs
+++ b/views/public/signup.ejs
@@ -15,12 +15,19 @@
         </p>
 
         <% if (typeof error !== 'undefined' && error) { %>
-        <div class="alert error"><%= error %></div>
-        <% } %> <% if (typeof success !== 'undefined' && success) { %>
-        <div class="alert success"><%= success %></div>
+        <div class="alert error" data-auth-message="error"><%= error %></div>
+        <% } else { %>
+        <div class="alert error" data-auth-message="error" hidden></div>
         <% } %>
+        <div class="alert success" data-auth-message="success" hidden></div>
 
-        <form action="/signup" method="post" class="stack" novalidate>
+        <form
+          action="/signup"
+          method="post"
+          class="stack"
+          novalidate
+          data-auth-form="signup"
+        >
           <% if (locals.csrfToken) { %>
           <input type="hidden" name="_csrf" value="<%= csrfToken %>" />
           <% } %>
@@ -81,5 +88,12 @@
     </main>
 
     <%- include('../partials/footer') %>
+    <script>
+      window.firebaseAuthPage = {
+        config: <%- JSON.stringify(firebaseConfig || {}) %>,
+        mode: "signup",
+      };
+    </script>
+    <script type="module" src="/js/firebase-auth.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the server-side authentication handlers to verify Firebase ID tokens, persist sessions, and reconcile MongoDB users with Firebase UIDs
- add client-side Firebase login and signup flows with Google sign-in, password reset, and automatic session syncing
- surface Firebase config to the UI, update auth views, and ensure logout clears Firebase state while keeping existing user data storage

## Testing
- npm install *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ea7aaa351483328acb74539a4e1dda